### PR TITLE
fix(analytics): stop overwriting window.gtag with Array-push wrapper

### DIFF
--- a/OpenDoorWebsiteApp/src/utils/analytics.ts
+++ b/OpenDoorWebsiteApp/src/utils/analytics.ts
@@ -27,13 +27,17 @@ export const initGA = (): void => {
     return;
   }
 
-  // Initialize dataLayer
-  window.dataLayer = window.dataLayer || [];
-  window.gtag = function(...args: any[]) {
-    window.dataLayer.push(args);
-  };
+  // dataLayer and window.gtag are already set up by the inline script in
+  // public/index.html. Do NOT reassign window.gtag here -- the inline version
+  // uses `arguments` (canonical gtag.js form). Any reassignment with a
+  // rest-parameter wrapper pushes real Arrays into dataLayer, which gtag.js
+  // silently ignores, causing zero events to reach GA4. See issue #35.
+  if (typeof window.gtag !== 'function') {
+    console.warn('Google Analytics: inline gtag shim missing from index.html; skipping config');
+    return;
+  }
 
-  // Configure gtag
+  // Configure gtag (uses the inline arguments-form shim)
   window.gtag('js', new Date());
   window.gtag('config', GA_MEASUREMENT_ID, GA_CONFIG);
 };


### PR DESCRIPTION
## Summary

Fixes #35 — GA4 property `G-9VW8X3YKJ6` received zero events in 28+ days.

## Root cause (empirically confirmed on live site)

`OpenDoorWebsiteApp/src/utils/analytics.ts:31-34` reassigned `window.gtag` at React-mount time with a rest-parameter wrapper:

```js
window.gtag = function(...args: any[]) {
  window.dataLayer.push(args);
};
```

This pushed real **Arrays** into `window.dataLayer`. The canonical gtag.js loaded async from googletagmanager expects each dataLayer entry to be an **Arguments object** (array-indexed with a `length` property) — which is what the inline shim at `public/index.html:69` correctly produces via `arguments`. Array-shaped entries are silently ignored by gtag.js, so no event ever reached GA4.

## Live-browser evidence

Investigation via DevTools MCP on https://www.opendoorph.org/opendoor/Home/Scripture:

- `window.dataLayer` contained 6 entries — all Array-shaped (starting `[`) instead of Arguments-like
- `window.gtag.toString()` returned the rest-parameter wrapper, confirming the override ran after the inline shim
- Clicked "Accept" on ConsentBanner and navigated to `/opendoor/Home/About` — **zero** requests to `google-analytics.com/g/collect` or `region1.google-analytics.com/g/collect` observed in the Network panel
- Console had no gtag errors — the bug is silent

Full investigation log: `.delivery/artifacts/issue-35-ga4/investigation.md` (committed alongside the fix on this branch? — actually under `.delivery/` which is gitignored; kept locally for reference).

## Fix

Delete the reassignment. The inline script in `public/index.html` already provides both `window.dataLayer` and a canonical `gtag()` function. `initGA()` only needs to call the existing `gtag('js', ...)` + `gtag('config', ...)`.

Added a defensive guard: if the inline shim is missing (shouldn't happen, but fails loud instead of silent), log a console warning and return.

## Test plan

- [ ] CI: build + Jest + a11y smoke + discourse-fidelity all green (no Scripture content changed)
- [ ] Post-deploy: fresh incognito to https://www.opendoorph.org, open DevTools → Network (filter `collect`), click Accept on ConsentBanner, navigate to any internal route — verify at least one `/g/collect` request fires within 5 seconds
- [ ] 24h follow-up: GA4 Admin → Data streams → Recent events shows `page_view` events from real traffic
- [ ] 7-day follow-up: star `add_to_calendar`, `contact_click`, `location_directions_click` as Key events (deferred from `.delivery/artifacts/ga4-config-2026-04-15/configuration-report.md`)

## Rollback

Single-file one-commit change. `git revert 42fe102` + redeploy restores prior state.

## Related

- Issue #35 (this PR closes it)
- Prior config work: `.delivery/artifacts/ga4-config-2026-04-15/configuration-report.md` (GA4 admin settings) — still valid, just starved of event data
- Issue #37 (E2E suite) — unrelated track

🤖 Generated with [Claude Code](https://claude.com/claude-code)
