### PR TITLE
fix(lint): silence eslint import/first on Jest mock-pattern imports

### DIFF
--- a/OpenDoorWebsiteApp/src/__tests__/napByteMatch.test.ts
+++ b/OpenDoorWebsiteApp/src/__tests__/napByteMatch.test.ts
@@ -72,10 +72,16 @@ jest.mock('../hooks/usePageMeta', () => ({
     usePageMeta: jest.fn(),
 }));
 
-// Imports AFTER mocks are registered.
+// Imports AFTER mocks are registered. Jest requires `jest.mock()` calls to
+// run before the modules under test are imported, which is enforced by
+// hoisting in babel-plugin-jest-hoist for `jest.mock` only — `import`
+// statements that depend on the mocks must come after. ESLint's
+// `import/first` doesn't recognize this pattern, so disable per-line.
+/* eslint-disable import/first */
 import Footer from '../components/layout/Footer/Footer';
 import { Location } from '../pages/LocationPage/LocationPage';
 import { About } from '../pages/AboutPage/AboutPage';
+/* eslint-enable import/first */
 
 const INDEX_HTML_PATH = path.resolve(
     __dirname,


### PR DESCRIPTION
## Summary
PR #60 introduced 3 `import/first` ESLint errors in `napByteMatch.test.ts` (lines 76-78) on the component imports that follow `jest.mock(...)` calls. This is what dropped CodeFactor's grade by -0.02.

The pattern (mock-before-import) is required by Jest: `jest.mock()` is hoisted by `babel-plugin-jest-hoist`, but the `import` statements that depend on those mocks cannot be hoisted above them. ESLint's `import/first` rule doesn't recognize this idiom.

## Fix
Wraps the 3 imports in `/* eslint-disable import/first */` … `/* eslint-enable */` with an inline comment explaining the constraint.

## Test plan
- [x] `npm test -- --testPathPattern=napByteMatch` — 3/3 passing
- [x] `npx eslint src/__tests__/napByteMatch.test.ts --max-warnings=0` — clean (was 3 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)