### PR TITLE
chore(shell): fix shellcheck SC2086 + SC2181 findings (closes #65)

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -195,7 +195,7 @@ jobs:
           fi
           
           echo "✅ Found CloudFront distribution: $DISTRIBUTION_ID"
-          echo "DISTRIBUTION_ID=$DISTRIBUTION_ID" >> $GITHUB_OUTPUT
+          echo "DISTRIBUTION_ID=$DISTRIBUTION_ID" >> "$GITHUB_OUTPUT"
       - name: Invalidate CloudFront cache
         run: |
           echo "🔄 Invalidating CloudFront cache..."

--- a/scripts/update-libraries.sh
+++ b/scripts/update-libraries.sh
@@ -153,8 +153,7 @@ echo "✅ Security audit completed"
 
 echo "📋 Step 8: Testing installation..."
 echo "Starting test build..."
-npm run build
-if [ $? -ne 0 ]; then
+if ! npm run build; then
     echo "❌ Build failed. Please check the errors above."
     exit 1
 fi


### PR DESCRIPTION
## Summary
Closes the local-linter gap from #65: 2 shell-side findings actionlint + shellcheck surface that ESLint doesn't (and CodeFactor likely flags as part of its 12-issue count vs ESLint's 8).

| File:Line | Rule | Fix |
|---|---|---|
| `.github/workflows/node-build.yml:198` | SC2086 (actionlint→shellcheck) | quote `$GITHUB_OUTPUT` |
| `scripts/update-libraries.sh:157` | SC2181 | `if ! npm run build; then` instead of `npm run build; if [ $? -ne 0 ]` |

## Investigation outcome (#65)
Local linters run:
- `shellcheck` (newly installed via brew) on all `*.sh` — 1 finding (SC2181 above)
- `actionlint` (newly installed via brew) on `.github/workflows/*.yml` — 1 finding (SC2086 above)
- `npx markdownlint-cli2` on README — 25+ findings, but with default rules; CodeFactor likely uses different config or doesn't lint markdown (count would be much higher than 12 if it did)
- `npx stylelint` on CSS — needs config (no default rules in v17); not run
- `npx htmlhint` on `public/index.html` — clean

Conclusion: the 2 fixes here are the actionable subset of the gap. Markdown and CSS lint debt remains untracked but isn't surfaced by CodeFactor at default thresholds.

## Test plan
- [x] `actionlint -no-color .github/workflows/*.yml` — clean (was 1 finding)
- [x] `shellcheck scripts/*.sh OpenDoorWebsiteApp/scripts/*.sh` — clean (was 1 finding)
- [x] Workflow change is +1/-1 (just adds quotes); BUG-053-01 deploy chain byte-identical pre/post

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)