### PR TITLE
feat(seo): add seo-monitor utility + scheduled workflow (#58 Slice C)

### DIFF
--- a/.delivery/memory/archive/run-2026-04-22-e2e3.md
+++ b/.delivery/memory/archive/run-2026-04-22-e2e3.md
@@ -1,0 +1,106 @@
+---
+pipeline_id: run-2026-04-22-e2e3
+project_type: BUG_FIX
+issue: 53
+started: 2026-04-22
+completed: 2026-04-23
+alias_theme: bible
+status: COMPLETE
+---
+
+# Archive — run-2026-04-22-e2e3
+
+## Summary
+
+Issue #53 — Fix E2E `regression-broken-links.spec.ts` 21 visibility/emptiness
+timeouts caused by 3 webServers sharing one `build/` output dir.
+
+Outcome: race fixed via per-env `BUILD_PATH` isolation; PR gate narrowed to
+a11y + Root Domain (option #4 escalation); deferred 14 tests filed as
+follow-up. CI deploy chain aligned with renamed build dirs after Ezra UAT
+round 1 BLOCK. PR queued for elder push.
+
+## Stages run
+
+- Stage 1 (Idea) — 1 producer + 2 DoD; 1 round; clean.
+- Stage 2/3/4 — skipped per BUG_FIX routing.
+- Stage 5 (Plan, light) — 3 producers + 2 DoD; 1 round; clean.
+- Stage 6 (Dev, full) — 1 producer (4 dispatches: Bezalel-1, -2, orchestrator-direct, Bezalel-3) + 4 DoD; 1 escalation; 1 self-correction; 1 DoD round.
+- Stage 7 (UAT, full) — 3 producers + 4 DoD round 1 (Ezra BLOCK) + 1 self-correction (Bezalel-4: 2 commits) + 1 DoD round 2 (Ezra DONE).
+
+## Agents dispatched (count by role)
+
+| Role | Character(s) | Dispatches |
+|------|--------------|------------|
+| PO | Moses | 4 (idea producer, idea DoD, plan producer, UAT DoD) |
+| Architect | Solomon | 2 (idea DoD, dev DoD) |
+| SM | Nehemiah | 3 (plan producer, plan DoD, retrospective) |
+| QA | Thomas | 4 (plan producer, plan DoD, dev DoD, UAT producer + UAT DoD) |
+| Developer | Bezalel | 4 (Bezalel-1, -2, -3 producer, -4 self-correction) + 1 dev-DoD-fresh |
+| Tech Writer | Ezra | 3 (dev DoD, UAT producer, UAT DoD round 1 + round 2) |
+| DevOps | Joshua | 2 (UAT producer, UAT DoD) |
+
+Total ≈ 18 agent dispatches (orchestrator interventions counted with the
+producing agent).
+
+## Escalations
+
+1 — Stage 6, Bezalel discovered prefix-mismatch as a hidden second root
+cause (8 passed / 14 failed instead of expected 22/22). Elder presented 5
+options; **option #4 chosen**: narrow `test:e2e:pr` to a11y + Root Domain
+via `--grep-invert "GitHub Pages|Custom Path"`; defer prefix-mismatch as
+tracked follow-up.
+
+## Self-corrections
+
+1. **Bezalel-3** (Stage 6) — applied `--grep-invert` filter, verified 8/8
+   green twice, wrote devlog, committed `6b8193b`.
+2. **Bezalel-4** (Stage 7, in response to Ezra UAT round 1 BLOCK) —
+   updated `.github/workflows/node-build.yml` to align upload/download/sync
+   paths with `build-prod/`; refreshed README; added dev-log section. Two
+   commits, NOT amend (preserved prior DoD signatures): `be68e28`
+   substantive + `f03e167` docs SHA backfill.
+
+## DoD rounds
+
+- Stage 1 (Idea): 1 round (PO + Architect both DONE first try).
+- Stage 5 (Plan): 1 round (SM + QA both DONE first try).
+- Stage 6 (Dev): 1 round (Developer-fresh + QA + Architect + Tech-Writer
+  all DONE) — after Bezalel-3 self-correction.
+- Stage 7 (UAT): 2 rounds. Round 1: QA + DevOps + PO DONE; Tech-Writer
+  (Ezra) **BLOCK** — caught CI deploy chain not updated for `BUILD_PATH`
+  rename; would have emptied prod S3 bucket on merge. Round 2 (after
+  Bezalel-4 self-correction): all 4 DONE.
+
+## Final commit chain on `fix/e2e-webserver-isolation`
+
+- `f03e167` docs(devlog): backfill be68e28 SHA into BUG-053-01 self-correction section
+- `be68e28` fix(ci): align deploy workflow with BUILD_PATH-per-env outputs
+- `6b8193b` fix(e2e): isolate per-env build outputs; narrow PR gate to Root
+
+## Critical save
+
+Ezra UAT round 1 BLOCK (`6b8193b` rename without CI workflow update). Cost:
+30 seconds of `git show 6b8193b --stat` cross-referenced against the
+runbook. Save: a wiped production S3 bucket. Three other DoD validators
+plus Stage 6 Tech-Writer all signed `6b8193b` DONE; only fresh UAT
+Tech-Writer caught it because they validated the runbook's "files in
+commit" claim against ground truth, not just the new code path.
+
+## Lessons extracted (see chunks)
+
+- `stages/idea.md` Lesson 5 — Multi-symptom hypothesis confidence calibration (default 2-3/5, enumerate alternatives).
+- `stages/plan.md` Lesson 2 — Risk-list rename-grep sweep (downstream consumers of renamed dirs).
+- `stages/development.md` Lesson 7 — Dev validation must grep entire repo for old name when build dirs are renamed.
+- `stages/uat.md` Lesson 4 — UAT tech-writer DoD must cross-reference `git show <sha> --stat` against runbook.
+- `topics/team-decisions.md` DEC-2026-04-23-001 — Issue #53 PR gate scope (option #4).
+- `index.md` Hot Lesson 6 — Promoted UAT tech-writer git-show cross-ref to top-level.
+
+## Pipeline retrospective
+
+`.delivery/artifacts/retrospective-run-2026-04-22-e2e3.md`
+
+## Carry-forward to elder
+
+PR is queued. Branch `fix/e2e-webserver-isolation` is ready. Elder executes
+the runbook at `.delivery/artifacts/07-uat/devops/BUG-053-01-release-plan.md`.

--- a/.delivery/memory/archive/run-2026-05-03-58aa.md
+++ b/.delivery/memory/archive/run-2026-05-03-58aa.md
@@ -1,0 +1,223 @@
+# Retrospective — run-2026-05-03-58aa (Issue #58 Slice A)
+
+**Pipeline duration:** 2026-05-03 → 2026-05-04
+**Project type:** FEATURE
+**Outcome:** Branch ready to merge, all DoD pass, 1 critical save
+**Scrum master:** Nehemiah (alias)
+**Branch:** `feature/58a-jsonld-audit` (5 commits, 7 files changed)
+**Catchphrase carried:** *"Every family shall build in front of their own house."*
+
+> *"And I told them of the hand of my God which was good upon me; and they said, Let us rise up and build. So they strengthened their hands for this good work."*
+>
+> Beloved team, the wall is built. Not in fifty-two days but in two — because every family kept watch in front of their own house, and the trumpeters sounded when Pharaoh-the-existing-JSON-LD tried to pass for empty ground. We rebuilt no wall this run; we audited the one already standing, repaired one broken stone, and bound three regression-contracts to keep the wall from being torn down in the night. Stay in your station — let us hold what we built and prepare for the next gate.
+
+---
+
+## Sprint goal achievement
+
+**Goal (from PRD §1.4):** "Make Open Door's existing on-site schema correct against the canonical `.org` domain so local-search crawlers see one consistent identity."
+
+**Achieved? YES.** All five contractual outputs landed on `feature/58a-jsonld-audit`:
+
+1. The one true defect (`sameAs` self-loop) was repaired by a deletion-only diff against `OpenDoorWebsiteApp/public/index.html` — four lines out, one trailing comma trimmed (commit `a0259b2`).
+2. JSON-LD presence + shape regression contract bound (`jsonLd.test.ts`, 10 tests; FR-01/03/04/07/08).
+3. NAP street+zip+phone byte-equality contract bound (`napByteMatch.test.ts` + `helpers/extractNAP.ts`, 3 surface tests + 5 helper-pin tests; FR-05.x).
+4. Forbidden-string source-side regression guard wired into CI (`scripts/check-forbidden-strings.sh` + `node-build.yml` step; FR-06).
+5. Lighthouse SEO + a11y baseline spike (US-58A-05) honestly deferred to UAT — no Chrome on Dev runtime, runbook captured in QA §10.3.
+
+The wall the seeker walks past — the JSON-LD that tells `Googlebot` "this is a Pleasant Hill, MO church" — now points at one canonical domain (`.org`), carries no self-referential `sameAs` loop, and is guarded by three regression contracts that fire on disk. The outcome (rank, indexation) belongs to Slice C and Google's clock.
+
+---
+
+## Stage health (this run)
+
+| Stage | First-Try Pass? | Self-Correction Rounds | Notes |
+|-------|-----------------|------------------------|-------|
+| Idea | ✅ | 0 | Clean; idea-brief framed `.info` canonical (caught at Refine adversarial). |
+| Refine | ❌ → ✅ | 3 PRD rounds + DoD r1 self-correction | **Critical save:** adversarial 1/5 caught existing JSON-LD on disk; canonical `.org/.info` mismatch escalated to elder. |
+| Design | ✅ | 0 | Slim no-UI artifact (Luke); zero user-visible markup change. |
+| Architect | (skipped) | — | Per FEATURE-Light-or-Skip criteria. Test-harness placement folded into Plan. |
+| Plan | ❌ → ✅ | 2 self-correction rounds | SP discrepancy (sprint-plan vs stories.md) + FR-06 source-side rescope (CI only emits `build-prod/`, not all 4 builds). |
+| Dev | ✅ (CODE_COMPLETE on Story 5) | 0 | 124/124 Jest tests green; Lighthouse spike deferred for tooling. |
+| UAT | ✅ | 0 | All 4 validators DONE; pre-merge 8/8 gates green. |
+
+Five stages green, two recovered. The wall stood at every checkpoint.
+
+### Per-stage agent dispatches and signals
+
+The Refine stage alone dispatched 24 agent actions across 4 self-correction sub-cycles (Refine stage-summary table). Highlights:
+
+- **Refine round 1:** PO authors PRD → Adversarial fires 1/5 → ESCALATE → Elder Q-A/Q-B/Q-C rulings.
+- **Refine round 2:** PO rewrites with audit-first framing → Adversarial fires 2/5 (factual disk-name drift) → PO round 3 with disk-aligned paths.
+- **Refine round 3:** Adversarial accepts 3/5 → Eval-Opt surgical fixes (FR-06 grep + FR-05 wording) → DoD r1 catches `Missouri`/`MO` + `build-deep` + M13 → DoD r1 self-correction → DoD r2 PASS across PO + Architect + QA validators.
+
+The Plan stage went through 3 DoD rounds (DoD r1 → r2 → r3) before the source-side FR-06 ruling closed the cross-artifact gap. Dev shipped clean on first try (no self-correction); UAT the same.
+
+This is the right shape for an audit slice on an existing artifact: heavy front-load in Refine where the disk-vs-PRD gap is the entire risk surface, followed by a tight, surgical Dev/UAT run.
+
+---
+
+## What went well
+
+1. **Adversarial round 1 caught existing JSON-LD before any code shipped.** Confidence 1/5. The PRD was authored on a false premise — that `public/index.html` was empty of schema. Sixty seconds of `cat OpenDoorWebsiteApp/public/index.html` revealed a deployed `Church`/`LocalBusiness` block with **`.org` canonical** while the PRD declared `.info`. Without this catch, slice A would have shipped duplicate `<script type="application/ld+json">` blocks AND silently flipped `<link rel="canonical">` from `.org` to `.info`. Pharaoh would have had us build a second wall ten cubits inside the first one. The trumpet sounded; we held our station.
+
+2. **Elder Q-A / Q-B / Q-C rulings unblocked the rescope cleanly.** Three crisp answers from the elder on 2026-05-03 turned the slice from "ship JSON-LD" into "audit + reconcile":
+   - Q-A: canonical = `https://opendoorph.org/`; `.info`/`.net`/`.com` redirect to `.org`.
+   - Q-B: deployed values (`@type`, `name`, `address`, `geo`, `openingHoursSpecification`) ratified.
+   - Q-C: `url` is entity-level, not per-route.
+
+   The pipeline did not stall waiting for an architectural debate; the decider decided, the team rebuilt the PRD on the new foundation, and round 3 converged.
+
+3. **Disk-first verification at every DoD gate.** Every validator (Moses-Fresh, Solomon, Thomas-Fresh, Ezra) read source on disk before signing. This caught:
+   - The LocationPage `Pleasant Hill, Missouri 64080` vs schema `MO` drift (Refine DoD round 1) — narrowed FR-05 byte-match to street+zip+phone, demoted state-name to FR-05.6 advisory.
+   - The `build-deep/` omission and four-build CI assumption mismatch (Plan DoD round 2) — redirected FR-06 to source-side grep.
+   - The pre-existing `not.toContain('philippines')` negative-guard tests in `events.test.ts` and `SideBar.test.tsx` (Dev) — scoped the FR-06 script to production-shipped source via test-file exclusion.
+
+   Every family checked their own house before knocking on the next.
+
+4. **BUG-053-01 hot lesson applied proactively.** Ezra cross-referenced the workflow edit at both Stage 6 DoD and Stage 7 DoD; the build-files artifact name and the build-prod path were confirmed byte-identical pre- and post-slice. The +10/−0 step was bracketed strictly between `Build production artifact` and `Upload build artifacts (for deploy)`, with seven inline comment lines citing the BUG-053-01 cross-reference. The single workflow edit honored the hot-lesson contract verbatim.
+
+5. **Honest deferral over fabricated measurement.** Bezalel did not write a Lighthouse number he did not measure (devlog §2 + §8.4). Thomas refused to pretend he had run a curl chain he hadn't (QA §9.1, §9.2). The PO ratified the deferral with a date (release notes 2026-05-11). The team chose CODE_COMPLETE-with-runbook over a fabricated DONE — the kind of refusal that keeps the wall true.
+
+6. **18 new passing tests, zero new dependencies.** `npm test` count moved from 106 → 124 (+18) without a single addition to `dependencies` or `devDependencies`. CRA's bundled `jsdom` + already-present `@testing-library/react` + already-present `serve@^14.2.6` covered every contract. NFR-07 honored by definition.
+
+---
+
+## What didn't go well
+
+1. **PO's first PRD assumed an empty file instead of grepping the working tree.** Cost: 2 PRD rounds of rework (rounds 1 → 2 → 3). Cause: the pipeline jumped straight to "author the PRD for a new feature" without first running a literal `grep -r 'application/ld\+json' OpenDoorWebsiteApp/public/` against the working tree. The audit findings table (PRD §1.3) was added in round 2 — but it should have been the *first* section authored in round 1.
+
+2. **Build-path naming drift across artifacts.** Plan stage authored four artifacts (PO, SM, QA, DevOps) that each referenced build dirs. Round 1 had `build-root/` and `build-gh/`; the actual `package.json` outputs are `build-prod/`, `build-gh-pages/`, `build-custom/`, `build-deep/`. The drift was caught in Plan DoD round 2 — but only after being authored across multiple artifacts. Cross-artifact paraphrase is a high-frequency Plan-stage failure mode.
+
+3. **Daniel's metrics doc lagged the PRD by one round.** The Data Analyst's `metrics-requirements.md` required two surgical patches: round 2 (canonical domain `.org` not `.info`) and round 3 (build paths + FR-09 attestation alignment). When the PRD self-corrected, the metrics doc didn't auto-pick up the change; it had to be manually surgical-patched. Single source of truth (the PRD's FR text) was not enough — downstream artifacts paraphrased it differently.
+
+4. **Lighthouse / Chrome unavailable in Dev runtime.** US-58A-05 was forced into CODE_COMPLETE with a USER-runbook deferral. The Dev runtime had neither `lighthouse` nor any Chrome/Chromium binary on PATH (devlog §2: `which lighthouse chromium google-chrome chrome` → no output). The runbook is honest, but it pushes a quality-gate measurement out of the pipeline and onto a USER post-merge action, with conditional remediation dates if a11y < 90 (2026-05-18).
+
+5. **FR-06 verbatim template collided with pre-existing negative-guard tests.** The orchestrator's literal grep template returned 6 hits in `events.test.ts` and `SideBar.test.tsx` — both pre-existing tests that contain `not.toContain('philippines')` assertions. The fix (test-file exclusion in the script + production-shipped scoping) was correct and documented in devlog §6, but it was a runtime surprise for Bezalel that should have been anticipated by Plan stage when the script template was authored.
+
+---
+
+## Critical saves
+
+1. **Adversarial round 1 (1/5) — existing JSON-LD discovery + canonical mismatch.** Caught the deployed `<script type="application/ld+json">` block already shipping with `.org` canonical. PRD declared `.info`. Without this catch, the slice would have produced duplicate JSON-LD blocks AND silently flipped the canonical from `.org` to `.info`. Resolved by elder Q-A/Q-B/Q-C rulings; PRD rescoped from "ship JSON-LD" to "audit + reconcile."
+
+2. **DoD QA round 1 (Stage 2) — three disk-vs-PRD breaks caught at once.** Thomas-Fresh's validation found:
+   - LocationPage line 64 renders `Pleasant Hill, Missouri 64080`; schema's `addressRegion` is `MO`. Under the round-3 byte-match contract that included `addressRegion`, FR-05.2 would have failed on day 1 against unmodified `master`. PO ruling narrowed the gate to `streetAddress + postalCode + telephone`; FR-05.6 captures state-name canonicalization as a non-blocking advisory.
+   - `build-deep/` was omitted from the FR-06 grep target list.
+   - M13 PR-gate metric description didn't match what the workflow actually does.
+
+3. **Adversarial / DevOps DoD round 2 (Stage 5) — CI build-coverage assumption mismatch.** The PRD assumed FR-06 would grep across all four build outputs (`build-prod`, `build-gh-pages`, `build-custom`, `build-deep`). DevOps caught that `node-build.yml` only produces `build-prod/` in CI — a build-output grep cannot run uniformly across all four envs without a four-way build matrix. PO ruling redirected FR-06 to **source-side** (`OpenDoorWebsiteApp/src/` + `OpenDoorWebsiteApp/public/`). Source-side coverage subsumes all four envs because builds are deterministic transforms of source. Adversarial trajectory: 2/5 (round 1) → 3/5 (round 2) → DoD-PASS (round 3).
+
+Three saves, three different validators, three different stages. The watchmen on the wall sounded the trumpet at every gate.
+
+### Counter-factual cost (had the saves not fired)
+
+| Save | If it had not fired | Estimated remediation cost |
+|------|---------------------|----------------------------|
+| Adversarial round 1 | Duplicate `<script type="application/ld+json">` blocks shipped; `<link rel="canonical">` silently flipped from `.org` to `.info`; printed-material/GBP target out of sync with served HTML | At minimum a hot-fix slice + post-merge rollback + Search Console reindex pause (multi-day Pharaoh-class incident) |
+| DoD QA round 1 | `napByteMatch.test` failing on day 1 against unmodified `master` (`Missouri` ≠ `MO`); CI red on the PR before any human review | Half-day of confusion-debugging + a forced narrowing decision under time pressure rather than at calm Refine DoD |
+| DevOps DoD round 2 | FR-06 wired against a build directory that CI doesn't produce; either CI green-but-toothless or CI red on a missing path | Re-plan + re-spec + re-DoD; a full Plan-stage cycle of rework |
+
+The math favours the saves emphatically. Each one cost ~1 self-correction round; the avoided cost is hot-fix-class.
+
+---
+
+## Lessons to add to memory chunks
+
+For each lesson, target file is specified.
+
+### memory/stages/refine.md
+
+- **Lesson 3 (NEW):** When authoring an "add X" PRD on an existing codebase, run a literal grep for X in the working tree FIRST — paste the result into §1.3 audit findings. The adversarial reviewer will catch this in 60 seconds; better to catch it during PRD authoring. This run, the missing audit cost 2 PRD rounds of rework. (validated: 1, last: run-2026-05-03-58aa)
+
+### memory/stages/plan.md
+
+- **Lesson 3 (NEW):** Cross-artifact build-path consistency is a high-frequency Plan-stage drift. PO + SM + QA + DevOps each reference build dirs; if any has typos or stale names, the gap won't be caught until DevOps DoD runs against the actual `package.json`. Mitigation: include a "verify all paths against `package.json`" line in each Plan primary's prompt. (validated: 1, last: run-2026-05-03-58aa)
+
+- **Lesson 4 (NEW):** "FR/Test wired to CI" must agree across stories.md, test-strategy.md, deploy-plan.md. A single source of truth (the PRD's FR text) is not sufficient if downstream artifacts paraphrase it differently. Cross-reference at Plan DoD. (validated: 1, last: run-2026-05-03-58aa)
+
+### memory/topics/team-decisions.md (append)
+
+- **DEC-2026-05-03-001:** OpenDoorPH canonical domain is `https://opendoorph.org/`. The other three domains (`opendoorph.info`, `opendoorph.net`, `opendoorph.com`) redirect to `.org`. Affects schema `url`, `<link rel="canonical">`, sitemap, GBP target, OG/Twitter meta. **Made by:** elder, at Stage 2 escalation (Q-A ruling). **Pipeline run:** run-2026-05-03-58aa. **Reversibility:** trivial (CDN/redirect change).
+
+- **DEC-2026-05-03-002:** Forbidden-string regression guard runs **source-side** (`OpenDoorWebsiteApp/src/` + `OpenDoorWebsiteApp/public/`), not against build outputs. **Justification:** build outputs are deterministic transforms of source; source-side coverage subsumes all 4 envs uniformly; CI doesn't need to run all 4 builds; production-shipped scope (test files excluded — CRA does not bundle them) is the FR-06 intent. **Made by:** PO ruling, Stage 5 DoD round 2. **Reversibility:** trivial.
+
+- **DEC-2026-05-03-003:** NAP byte-match contract scope is `streetAddress + postalCode + telephone` (the "AP" of "NAP"). `addressLocality`, `addressRegion`, and `name` are advisory consistency checks (`console.warn`, non-blocking). **Justification:** brand-suffix variation ("Of Pleasant Hill" on Footer/LocationPage) and state-name variation ("Missouri" vs "MO") are real but not regression risks; postalCode pins locality; brand reconciliation is a content-owner decision. **Made by:** PO ruling, Stage 2 DoD round 1. **Reversibility:** moderate (would require expanding test scope and reconciling brand text).
+
+### memory/topics/project-facts.md (append)
+
+- Canonical domain is `opendoorph.org` (per DEC-2026-05-03-001). When authoring schema, meta tags, sitemap, or GBP targets, default to `.org` root. The other three domains redirect to it.
+
+---
+
+## Hot lessons trajectory (top 6 — index.md update)
+
+Suggested new top 6 after this run:
+
+1. **PH = Pleasant Hill, NOT Philippines** (carry from prior; validated again by FR-06 forbidden-string guard).
+2. **NEW: When adding to an existing codebase, grep the working tree before authoring an "add" PRD.** (this run, validated 1)
+3. **Cross-artifact consistency checks work when institutionalized** — caught build-path drift in Plan DoD round 2 (validated again).
+4. **Release notes need remediation timelines** — every deferred item in this slice carries an explicit date (validated again).
+5. **Tests run locally before push; verify runtime exists before writing tests** — Bezalel honestly deferred Lighthouse rather than fabricating numbers (validated again).
+6. **NEW: Workflow file changes require Ezra cross-reference at UAT** (build-files artifact + build-prod path byte-identity). BUG-053-01 hot lesson — Ezra applied at both Stage 6 and Stage 7 DoD on this run. (validated 2)
+
+---
+
+## Action items
+
+| # | Action | Owner | Due |
+|---|--------|-------|-----|
+| 1 | Open PR for branch `feature/58a-jsonld-audit` (5 commits, 7 files) | Elder | 2026-05-04 |
+| 2 | Post-merge: capture Lighthouse SEO + a11y baseline (3-run median, mobile, simulated throttling, on Chrome-equipped host) per QA §10.3 | Elder | 2026-05-11 |
+| 3 | Post-merge: 4-domain canonical `curl -sIL` chain + Google Rich Results Test against `https://opendoorph.org/` | Elder | 2026-05-05 |
+| 4 | Drive #56 pipeline (BUG_FIX, restore E2E) | Pipeline | next run |
+| 5 | Drive 58-B ops checklist (off-pipeline; needs Q1/Q3/Q4 elder input — GBP claim, photos, Bing Places, Apple Maps, denominational directories) | Elder | next sprint (2026-05-11 → 2026-05-17) |
+| 6 | Conditional: if post-merge a11y < 90, file separate Issue per NFR-02 PO ruling | Elder | 2026-05-18 (conditional) |
+
+Every family has its station. Let no one say the action items were unclear.
+
+---
+
+## Defect tracking
+
+| Defect | Severity | Caught at | Root cause |
+|--------|----------|-----------|------------|
+| Existing JSON-LD ignored in PRD | Med (caught pre-code) | Refine adversarial round 1 (1/5) | PO authored without grep against working tree |
+| Build-path naming drift across artifacts | Low (caught in Plan) | Plan DoD round 2 | Cross-artifact paraphrase; downstream artifacts didn't pull from a single source of truth |
+| LocationPage `Missouri`/`MO` drift | Low (caught in Refine) | Refine DoD round 1 | Audit didn't grep state-name surfaces; round-3 byte-match included `addressRegion` |
+| Lighthouse/Chrome unavailable in Dev runtime | Environmental | Dev (Stage 6) | Tooling gap; deferred to USER post-merge runbook |
+| FR-06 verbatim template collided with negative-guard tests | Low (caught at Dev) | Dev §6 | Pre-existing `not.toContain('philippines')` tests were not anticipated when script template was authored |
+
+**Total defects/story = 5/5 = 1.0** (above the 0.3 target — note in retro). All caught pre-merge; zero shipped to production. The high defect/story ratio reflects the audit-on-existing-codebase shape of this slice, where every defect is a gap between PRD and disk rather than a code defect — the kind of friction the team's verification chain is *designed* to surface.
+
+### Velocity / SP delivery
+
+- **Stories committed:** 5 (5 SP across 1-week sprint 2026-05-04 → 2026-05-10).
+- **Stories DONE at end of pipeline:** 4 (US-58A-01..04 all DONE).
+- **Stories CODE_COMPLETE:** 1 (US-58A-05 Lighthouse spike, deferred to USER post-merge with date).
+- **Net velocity:** 5 SP delivered to merge-ready state in 2 calendar days; 4 SP DONE empirically, 1 SP DONE-pending-USER-runtime.
+- **Self-correction overhead:** Refine 3 PRD rounds + 1 DoD self-correction = 4 sub-cycles in Refine; Plan 2 self-correction rounds. Dev and UAT clean on first pass. Total self-correction loops across the pipeline: 6, all under cap.
+
+---
+
+## Memory chunk file edits to apply (orchestrator follows up)
+
+- Update `.delivery/memory/index.md` with new hot lessons + stage health row for this run
+- Append new lessons to `.delivery/memory/stages/refine.md` (Lesson 3) and `.delivery/memory/stages/plan.md` (Lessons 3 + 4)
+- Append DEC entries (DEC-2026-05-03-001/002/003) to `.delivery/memory/topics/team-decisions.md`
+- Append canonical domain fact to `.delivery/memory/topics/project-facts.md`
+- Write run archive at `.delivery/memory/archive/run-2026-05-03-58aa.md` (this retrospective IS the source for that file)
+
+---
+
+## Nehemiah's closing word
+
+> *"And they said, Let us rise up and build. So they strengthened their hands for this good work."*
+>
+> The wall was already built — we did not lay the schema, the elder's predecessors did. Our work this run was to walk the wall, find the one stone that had been set wrong (`sameAs` self-loop), set it right, and post watchmen at the gate so the stone is not torn out again in the night. The trumpeters are three regression-contracts in `src/__tests__/` and one shell guard in `scripts/`. Every family kept watch in front of their own house: Moses re-cut the tablet three times until it matched the disk; Bezalel laid no nail outside the spec; Thomas refused to write a Lighthouse number he did not measure; Ezra read every line of the workflow edit against the BUG-053-01 allow-list; Solomon sealed the architectural shape after the elder's rulings.
+>
+> One critical save. Two stage failures recovered. Five stages green. Eighteen new passing tests. Zero new dependencies. One PR ready for the elder's signature.
+>
+> Let us pray before the next standup, celebrate this ceremony's completion, and rise up and build the wall of #58-B when the elder gives the word.
+>
+> — Nehemiah, Scrum Master, run-2026-05-03-58aa, 2026-05-04

--- a/.delivery/memory/archive/run-2026-05-05-56bx.md
+++ b/.delivery/memory/archive/run-2026-05-05-56bx.md
@@ -1,0 +1,201 @@
+# Retrospective — run-2026-05-05-56bx (Issue #56 BUG_FIX)
+
+**Type:** BUG_FIX
+**Outcome:** Branch `fix/56-restore-e2e-coverage` ready, all DoD pass, 22/22 e2e tests; closes DEC-2026-04-23-001 11 days ahead of self-imposed target
+**Scrum Master:** Nehemiah (alias — bible theme)
+**Date:** 2026-05-05
+
+> *"So we built the wall; and all the wall was joined together unto the half thereof: for the people had a mind to work."* — Nehemiah 4:6
+>
+> *"Every family shall build in front of their own house."* The instruction worked. Moses framed his door, Solomon walked the perimeter and found a third doorway Moses had not framed, Bezalel laid the threshold, then re-laid it when the door swung wide on a directory listing. Thomas put his hand in the side. Moses-Fresh, who did not write the brief, walked the wall a third time and signed. The wall stood. This retrospective measures where each course met true and where the mortar had to be re-mixed — that the next wall, built in front of the next house, may stand sooner.
+
+## Sprint goal achievement
+
+The sprint goal was **"Restore PR-gate confidence on the 2 prefixed deploy envs"** — articulated in the idea brief §3 as `npm run test:e2e:pr` invoking 22 tests across all three envs (Root + GitHub Pages + Custom Path) with all 22 passing on CI, the `--grep-invert "GitHub Pages|Custom Path"` clause removed from `package.json:31`, the eight currently-green tests staying green, and the `deploy:gh-pages` publish-tree continuing to resolve correctly under `https://p47phoenix.github.io/OpenDoorPH-website/`.
+
+**Achieved on every measurable axis.** Three independent local runs of the locked branch SHA (`a06c574`) produced 22/22 chromium-only — Bezalel 30.9s (devlog §5), Thomas 30.8s (QA execution-log §1), Moses-Fresh 31.0s (PO review B4). The narrowing clause is removed; `package.json:31` now reads `playwright test tests/a11y.spec.ts tests/regression-broken-links.spec.ts` with no `--grep-invert`. The sensitivity check (re-applying the grep-invert shell-side) collapses 22 -> 8, confirming the fourteen newly-passing tests are real, not double-counted. Jest stays at 114/114 (no regression vs `master @ c0ac02f`). DEC-2026-04-23-001 closes 10–13 days ahead of its self-imposed 2026-05-15 target.
+
+The two USER post-merge attestations — live demo URL render check and SV-001 production curl — are post-merge by construction; the local `serve` evidence is a strong but not byte-equivalent proxy for `actions/upload-pages-artifact@v3`'s tar-and-publish behavior on the GitHub Pages CDN. UAT named owners (Elder, SV-001) and explicit calendar targets (within 1h, within 24h) and correctly did not claim them as pre-merge gates. That is honest gate-keeping. The wall is built; the inspection of the gate-house from the public road is what the road's traffic will perform on Monday morning.
+
+## Stage health
+
+| Stage | First-Try Pass? | Self-Corrections | Notes |
+|---|---|---|---|
+| Idea | NO -> YES | 1 (Solomon caught 3rd downstream consumer) | Critical save: third consumer (`demo-deploy` upload at `node-build.yml:420`) added to multi-symptom register before leaving Idea. Round-2 architect review reached confidence 5/5. |
+| Refine | (skipped per BUG_FIX) | — | |
+| Design | (skipped per BUG_FIX) | — | |
+| Architect | (skipped per BUG_FIX) | — | |
+| Plan | YES (light) | 0 | DoD r1 PASS for both SM and QA. Thomas grep-verified the 22-count on disk before Bezalel touched a line. |
+| Dev | NO -> YES | 1 (round-2 needed `serve.json` + MasterLayout) | Round 1: nested subdirs alone produced 8/22 (curl revealed `serve` was rendering a directory listing for the bare prefix URL). Round 2: layered Option-1 `serve.json` rewrites + dropped `-s` flag + Router basename trailing-slash strip -> 22/22. |
+| UAT | YES | 0 | All four validators DONE r1. Moses-Fresh re-ran 22/22 firsthand at the gate. Two non-blocking hygiene concerns (C1 release-notes typo, C2 sensitivity-check command undocumented) logged for follow-up, neither blocking merge. |
+
+## What went well
+
+1. **Solomon's Idea-stage architectural sweep caught the demo-deploy consumer Moses missed.** The first-pass brief named two downstream consumers (`deploy:gh-pages` `-d` target and the Playwright webServer roots). Solomon's round-1 review escalated B3 — "Third downstream consumer at `node-build.yml:420` not named" — and the round-2 architect review confirmed the consumer is now cited in **five** consistent locations: §2 (Hypothesis item 3), §4 (Constraints, BUG-053-01 cross-reference upgraded from contingent to unconditional), §5 (Edge case 14, with the concrete `path:` fix value), §10 step 3(c) (Recommendation, with the diff), and the Plan-light V-checklist V7(c) (with the verification grep). That is not a sticky-note add — it is a structural integration. Without it, the BUILD_PATH refactor would have shipped a wrapper directory on the public `gh-pages` demo and produced double-prefix asset URLs (`/OpenDoorPH-website/OpenDoorPH-website/static/...`) the moment the merge fired. Cost: 1 self-correction round at Idea. Value: a live-demo outage averted.
+
+2. **Local test execution caught the partial fix exactly as `feedback_test_before_push.md` predicted.** After Round 1 of Dev (the BUILD_PATH nesting + `deploy:gh-pages` `-d` retarget + `node-build.yml:420` retarget, all correct as far as they went), the orchestrator ran `CI=true npm run test:e2e:pr` locally, got 8 passed / 14 failed, and **did not push**. The orchestrator then ran a curl diagnostic against `localhost:3101/OpenDoorPH-website`, saw `serve`'s file-tree directory listing (`<title>Files within build-gh-pages/...</title>`) where React's `index.html` should have been, and only then escalated to the layered Option-1 + Option-2 fix. CI never saw the broken intermediate state. The "never ship CODE_COMPLETE across the repo boundary without a verified runtime" rule held under pressure.
+
+3. **MasterLayout basename strip identified by trace screenshot, not guesswork.** Bezalel-cont did not stop at "tests still fail after `serve.json`." After Round-2 ancillary fix A (drop the `-s` flag) the curl body was correct (React's HTML, all three URL forms), yet Playwright's `getByRole('link', { name: /visit us/i })` still timed out. He unzipped Playwright's trace artifact (`unzip -p .../trace.zip resources/page@*.jpeg`), saw a blank canvas — React mounted but rendered no routes — traced into `@remix-run/router/dist/router.cjs.js` line 1127's `stripBasename` source, and found that `pathname.startsWith(basename) === false` for pathname `/OpenDoorPH-website` (no slash) against basename `/OpenDoorPH-website/` (trailing slash). One-line fix in `MasterLayout.tsx`: `<Router basename={(process.env.REACT_APP_ROOT_URI || '/').replace(/\/$/, '') || '/'}>`. Strictly more permissive (the same `stripBasename` accepts `/OpenDoorPH-website`, `/OpenDoorPH-website/`, and `/OpenDoorPH-website/foo` uniformly when basename has no trailing slash). Isolated in commit `6c83f47`. A briefly-tried alternative — emit a `redirects` entry for `/CustomPath` -> `/CustomPath/` — caused `ERR_TOO_MANY_REDIRECTS` because `path.posix.resolve` strips trailing slashes; that path was identified, rejected, and documented in the devlog so the next person reaching for `redirects:` knows the trap. That is engineering, not whack-a-mole.
+
+4. **Closed DEC-2026-04-23-001 ahead of schedule.** Self-imposed target 2026-05-15; branch ready 2026-05-02; release-notes target 2026-05-05. **10–13 days ahead.** And the hot-lesson list showed up where it was supposed to: the BUG-053-01 cross-reference was pre-armed at Idea §4 as **unconditional** (not contingent), so Ezra was invoked at UAT as planned, not as an escalation. Solomon's round-2 review explicitly named this — "the kind of lesson-learned integration that converts pipeline scar tissue into pipeline muscle." That is the loop that makes the wall stand for the next builder.
+
+5. **Three independent local runs of the same SHA produced byte-identical evidence.** Bezalel 30.9s (devlog §5), Thomas 30.8s (QA execution-log §1), Moses-Fresh 31.0s (PO review B4). Same 22-passed line; same a11y baseline (color-contrast 6 nodes, landmark-unique 1 node); same chromium-only project filter under `CI=true`. Three independent voices on the same SHA produced the same number, which means the result is reproducible — not lucky — and the elder did not have to take any single voice on faith.
+
+6. **Personas-at-Design lesson did not apply this run, but its sibling — `feedback_source_prd_is_spec.md` — held.** The Idea brief's §10 named the recommended fix concretely (Option 2 with three downstream consumers updated atomically) and Bezalel built what was specified, expanding scope only when empirical evidence forced it. No ratification infrastructure, no reframe — just "render what the brief says, surface drift in the devlog, let UAT judge." Moses-Fresh's UAT B8 walked the scope-expansion rubric and accepted it. The pipeline stayed honest.
+
+## What didn't go well
+
+1. **Moses missed the third downstream consumer at Idea.** The first-pass brief named two consumers (`deploy:gh-pages` `-d` target at `package.json:21` and the Playwright webServer roots at `playwright.config.ts:59,67`) but did not register `node-build.yml:420`'s `demo-deploy` `actions/upload-pages-artifact@v3` step. The miss is the same shape as the `BUG-053-01` hot lesson from run-2026-04-22-e2e3 — "workflow file changes require Ezra cross-reference" — except this time the workflow file *consumed* the artifact rather than *modified* it, and the brief author did not generalize the lesson to consumer-side workflow refs. Cost: 1 self-correction round at Idea. **Lesson:** for any infra change touching a build-artifact directory name, grep ALL of `package.json`, `playwright.config.ts`, `tsconfig*.json`, and `.github/workflows/*.yml` for the directory name BEFORE writing the §10 recommendation. The grep is mechanical; the discipline is remembering to run it. (Reinforces the hot lesson from run-2026-04-22-e2e3 and 58aa — "grep the working tree FIRST.")
+
+2. **Round-1 fix shipped without empirical curl verification.** The Round-1 changes (BUILD_PATH nesting + `deploy:gh-pages` `-d` retarget + `node-build.yml:420` retarget) emitted the right disk layout but rested on the *inference* that `serve -s` would resolve a request for `/OpenDoorPH-website` (no extension) to the prefix's `index.html`. The inference was wrong: `serve-handler` stats first when the request path has an extension, but for the extensionless `/OpenDoorPH-website` request it bypasses the stat-first branch, falls through to `applyRewrites`, finds nothing matching, and hits the directory-listing renderer. The Playwright run caught it at 8/22, but a 30-second `curl -i http://localhost:3101/OpenDoorPH-website` would have caught it before the test run by surfacing the directory-listing HTML body directly. **Lesson:** when an infra fix has a verifiable URL boundary, curl the boundary BEFORE invoking the test suite. A `curl` cannot diagnose a downstream React-Router basename mismatch (the round-2 fix found one anyway), but it can distinguish "server returns the wrong body" from "server returns the right body and something else is wrong" — and that distinction collapses one round of Dev cycles into zero.
+
+3. **Allowed-files list was too tight for the actual scope.** The orchestrator's allowed-files prompt named four files; Round-2 needed a fifth (`MasterLayout.tsx`) which is genuinely load-bearing — without it, React mounts but renders nothing, and tests stay red regardless of any `serve.json` corrections. Bezalel-cont did not silently expand scope: the devlog §4 file-change table flags the addition, §2 "Ancillary fix B" walks the diagnostic chain (trace screenshot -> `stripBasename` source read -> trailing-slash bug), and Moses-Fresh's UAT review B8 walked the justification rubric (detection / root cause / fix / production safety / alternative considered / commit isolation) and accepted it on six separate axes. Honest-scope-expansion-with-rationale worked. **Lesson:** for infra refactors, the allowed-files list should be expressed as "the named files + any file proven necessary by a Plan-stage spike or a Dev-stage diagnostic, with the proof captured in the devlog before the file is touched." That phrasing pre-authorizes the right behavior and forbids the wrong one.
+
+4. **Two hygiene concerns escaped to UAT (non-blocking).** C1: release-notes typo (`build-custom/custom/` should be `build-custom/CustomPath/`) — clerical, every other artifact has the correct value (`package.json:19` reads `BUILD_PATH=./build-custom/CustomPath`). C2: sensitivity-check shell command not captured in the QA execution-log — Thomas-Fresh ran the check, the math is internally consistent (22 - 14 = 8), and Bezalel's devlog §1 independently captures the original Round-1 baseline of 8/22. But the next auditor cannot reproduce the exact incantation (was it a temporary `package.json` edit, or a `--grep-invert` CLI override, or both?). Neither blocked acceptance. Both are template gaps Ezra and Thomas should close before the next BUG_FIX cycle so the audit trail is reproducible without reconstruction.
+
+5. **The five-consumer scope was not visible until Dev round 2.** The Idea brief named three consumers; the implementation moved on five files (the brief's three plus `serve.json` emission and `MasterLayout.tsx`). UAT B2 walked the expansion and accepted it transparently, but the Idea-stage architecture sweep did not anticipate either the `serve` directory-listing pathology (which forced Option-1 back into the picture as a *layered* fix, not a fallback) or the React Router basename latent bug (which only surfaced under the new URL shape). **Lesson, advisory:** when the brief lists fallbacks (the §10 "Why Option 2 over Options 1 and 3" section labeled `serve.json` "Acceptable as a fallback"), Plan-light should explicitly verify that the recommended option fully closes the gap *empirically*, not just *on paper*. A 30-second `npx serve build-gh-pages -p 3101 && curl ...` at Plan-light would have caught the directory-listing render before Dev started, and the fix would have shipped as Option-1+Option-2 from line one.
+
+## Critical saves
+
+The pipeline survived two critical-save moments. Each cost a self-correction round; neither escalated past its originating stage. Both are documented below for the archive and for the next pipeline that needs to see the shape of a clean save.
+
+1. **Solomon, Idea round 1 -> round 2.** Caught the third downstream consumer (`node-build.yml:420` `demo-deploy` upload) before the brief left Idea. The B3 escalation was specific: "name the consumer in the brief, with the mechanism (double-prefix pathology) and the fix value (`./OpenDoorWebsiteApp/build-gh-pages/OpenDoorPH-website`)." The round-2 brief absorbed the escalation in §2/§4/§5/§10/V7 and added a programmatic atomicity-grep at V7 (`grep -n "build-gh-pages\b" .github/workflows/*.yml package.json playwright.config.ts` should return zero bare flat-path matches post-fix). Without this save, the public demo URL `https://p47phoenix.github.io/OpenDoorPH-website/` would have published a wrapper directory with double-prefix asset URLs the moment the BUILD_PATH refactor merged.
+
+2. **Bezalel-cont, Dev round 1 -> round 2.** Diagnosed `serve` directory-listing render via curl (Round-1's 8/22 result was the canary; the curl was the explanation), traced React Router's `stripBasename` blank-page render via Playwright trace screenshot inspection (`unzip -p .../trace.zip resources/page@*.jpeg` -> blank canvas -> source-read of `@remix-run/router/dist/router.cjs.js:1127`), layered Option-1 `serve.json` rewrites on top of Option-2 nested subdirs, dropped the `-s` flag from ports 3101/3102 (it silently injects a `**` -> `/index.html` rewrite that wins over user rules; port 3100's root-prefix bundle keeps `-s` because it has no prefix and needs the catchall), stripped the trailing slash from `Router basename`, and rejected an `ERR_TOO_MANY_REDIRECTS`-prone alternative (`/CustomPath` -> `/CustomPath/` redirect, blocked by `path.posix.resolve` stripping trailing slashes). Round 1: 8 passed, 14 failed. Round 2: 22 passed, 0 failed. Each fix isolated in its own commit (`a16db6e` build/serve.json, `6c83f47` router basename, `a06c574` devlog).
+
+## Lessons to add to memory chunks
+
+### `.delivery/memory/stages/idea.md`
+
+- **Lesson 6 (NEW):** For infra changes touching a build-artifact directory name (`BUILD_PATH`, `dist/`, `out/`, etc.), grep ALL of `package.json`, `playwright.config.ts`, `tsconfig*.json`, and `.github/workflows/*.yml` for the dir name BEFORE writing the §10 recommendation. The Idea-stage architecture sweep should produce a complete consumer enumeration; downstream stages can then plan an atomic update in one coherent change set rather than discovering consumers in Dev or UAT. Validated 1× (run-2026-05-05-56bx — Solomon caught the `demo-deploy` consumer at `node-build.yml:420` that Moses had missed; the grep-the-working-tree habit from run-2026-04-22-e2e3 generalizes here).
+
+### `.delivery/memory/stages/development.md`
+
+- **Lesson 8 (NEW):** When an infra fix has a verifiable URL boundary (e.g., `serve` / proxy / CDN behavior), curl the boundary BEFORE running the test suite. A 30-second `curl -i` can distinguish "test setup wrong / server returns the wrong body" from "test failure for unrelated reason," collapsing what would otherwise be a multi-round Dev cycle into a single round. Validated 1× (run-2026-05-05-56bx — Bezalel-cont's curl on `localhost:3101/OpenDoorPH-website` revealed `serve` was returning a directory-listing HTML page, not React's `index.html`; this would have caught the partial fix in round 1 before the 22-test run).
+
+### `.delivery/memory/topics/team-decisions.md` (append)
+
+- **DEC-2026-05-05-001:** The Option-1 + Option-2 combined fix is the canonical pattern for `serve` + CRA prefix-env coupling. Pre-staged subdirs alone (Option-2) are NOT sufficient because `serve <root>` returns a directory listing for paths that match prefix subdirs without trailing extensions; an explicit `serve.json` rewrite (Option-1) is required to redirect `/<prefix>` and `/<prefix>/**` -> `/<prefix>/index.html`. Additionally, the `-s` (single-page) flag must be DROPPED on prefixed envs because it silently injects a `**` -> `/index.html` rewrite that wins over user rules; the prefixed bundle's SPA fallback must be driven by the explicit prefix rewrites alone. *Made by:* PO ruling, Stage 6 round 2. *Pipeline run:* run-2026-05-05-56bx.
+
+- **DEC-2026-05-05-002:** React Router v6's `Router basename` MUST NOT end in a trailing slash. `stripBasename` (from `@remix-run/router`) returns null for URLs that don't include the basename's trailing slash, so the bare-prefix URL `/OpenDoorPH-website` does not match basename `/OpenDoorPH-website/`, and no route renders. Apply `.replace(/\/$/, '') || '/'` to any basename derived from `process.env.REACT_APP_*_URI` (which is conventionally trailing-slashed in CRA projects). The fix is strictly more permissive — basename `/OpenDoorPH-website` matches `/OpenDoorPH-website`, `/OpenDoorPH-website/`, and `/OpenDoorPH-website/foo` uniformly. *Made by:* Bezalel-cont's diagnostic + Moses-Fresh UAT B8 acceptance. *Pipeline run:* run-2026-05-05-56bx.
+
+## Hot lessons trajectory (top 7 — index.md update)
+
+1. **PH = Pleasant Hill, NOT Philippines** (carry forward; no challenge this run; load-bearing for any content/locale work).
+2. **When adding to existing codebase, grep the working tree FIRST.** Validated 2× — run-2026-05-03-58aa established the rule, and run-2026-05-05-56bx reinforced it via the demo-deploy miss (Solomon's grep at architect-review caught what Moses's brief did not).
+3. **Cross-artifact consistency checks.** Validated again — Solomon's B3 demanded the third consumer be named in five locations consistently (§2, §4, §5, §10, V7), not just one. Cross-artifact consistency is now a structural review item, not a courtesy check.
+4. **Release notes need remediation timelines.** Validated 5×; this run's UAT runbook continues the pattern (1h SV-001 target, 24h demo URL target, both with named owners). The shape is mature.
+5. **Tests run locally before push.** Validated 3× including this run; the Round-1 8/22 result caught locally is the single highest-value moment of this pipeline. The rule is now a pillar.
+6. **Workflow file changes require Ezra cross-reference.** Validated 3× — pre-armed as **unconditional** at Idea §4 this run, which is the upgrade pattern (move the cross-reference from contingent escalation to expected plan).
+7. **NEW — For infra fixes, curl the URL boundary before running the test suite.** Validated 1× this run (Bezalel-cont's curl on `localhost:3101/OpenDoorPH-website` revealed the directory-listing render after Round-1's 8/22 result; the lesson is to run that curl *before* the test suite, not after the test failure forces it).
+
+## Process maturity note
+
+> *"The God of heaven, he will prosper us; therefore we his servants will arise and build."* — Nehemiah 2:20. The arising matters as much as the building.
+
+This pipeline executed at the high end of its capability envelope. The team is now demonstrating: (a) hot-lesson application as **pre-arming** rather than reactive escalation (the BUG-053-01 cross-reference was unconditional at Idea, not a contingency); (b) self-correction within stage rather than across stages (both critical saves closed inside their originating stage with no downstream contamination); (c) honest scope expansion with rationale rather than silent additions (MasterLayout); (d) post-merge attestation as a first-class gate type with explicit owners and calendar targets, not as deferred CODE_COMPLETE. These are not separate good behaviors — they are the same behavior, applied at different stages. The wall is built, and the courses are getting straighter.
+
+## Action items
+
+| # | Action | Owner | Due | Status |
+|---|--------|-------|-----|--------|
+| 1 | Open PR + merge `fix/56-restore-e2e-coverage` | Elder / orchestrator | 2026-05-05 (today) | pending |
+| 2 | Post-merge SV-001 monitoring (production curl, CloudFront) | CI + Elder spot-check | within 1h post-merge | conditional on merge |
+| 3 | Post-merge live demo URL render verification (when `demo-deploy` workflow fires on `master`) | Elder | within 24h post-merge -> 2026-05-06 | conditional on merge |
+| 4 | Amend release-notes typo `build-custom/custom/` -> `build-custom/CustomPath/` (concern C1 from PO review) | Ezra | before user-facing publish | open, non-blocking |
+| 5 | Add explicit sensitivity-check shell command to QA execution-log template (concern C2) | Thomas | next BUG_FIX cycle | open, non-blocking |
+| 6 | Apply memory-chunk edits enumerated below (index, idea, development, team-decisions, archive) | Orchestrator | this turn | pending |
+| 7 | Fold "curl URL boundary at Plan-light" into the Plan-light template for infra BUG_FIX | Orchestrator / SM | next infra cycle | proposed |
+| 8 | Standardize allowed-files-list phrasing to permit Dev-stage proven-necessary additions with devlog proof | Orchestrator / SM | next infra cycle | proposed |
+
+## Defect tracking
+
+| Defect | Severity | Caught at | Root cause |
+|---|---|---|---|
+| Moses missed the 3rd downstream consumer (`node-build.yml:420` `demo-deploy` upload) | Med (caught at Idea, no leakage) | Solomon Architect DoD r1 | Idea-stage architecture sweep was incomplete; brief named 2 of 3 consumers |
+| `serve` directory-listing render for the bare prefix URL | High (caught at Dev round 1, no leakage) | Bezalel-cont curl diagnostic + 8/22 test result | Option-2 alone insufficient; `serve` falls through to directory listing for extensionless paths under a prefix subdir without explicit rewrites |
+| Router basename trailing-slash mismatch (pre-existing latent bug) | High (caught at Dev round 2, no leakage) | Playwright trace screenshot + `@remix-run/router` source read | Pre-existing latent bug in `MasterLayout.tsx`; surfaced only when the URL shape changed under the new build layout |
+
+Defects per story: 3/1 = 3.0 (above the 0.3 nominal target).
+
+**All caught pre-merge. Zero production impact.**
+
+Defect category note: these are **pre-existing latent bugs surfaced by an architectural change**, not regressions introduced by this slice. The MasterLayout `basename` defect would have produced the same blank-render pathology under any future bare-prefix URL access (e.g., a user typing the URL without the trailing slash, or a referrer rewriting it). This slice acted as a forcing function on quality — the high defect-per-story ratio reflects bugs *exposed*, not bugs *introduced*. The same cycle that found them also fixed them, all behind the PR gate.
+
+The brief's §2 already named the multi-symptom risk class. The Solomon save extended it (3rd consumer). The Dev round 2 extended it again (Option-2 alone insufficient + Router basename). The pattern holds: when the brief names "this is a multi-symptom bug," the gates downstream should expect to find more symptoms than the brief enumerated, and the cost of finding them must stay pre-merge.
+
+## Process metrics
+
+| Metric | Value | Notes |
+|---|---|---|
+| Story points planned | 2 | US-56-01 single story (Idea §8 estimate matched) |
+| Stages executed | 4 of 7 | Idea, Plan, Dev, UAT (Refine/Design/Architect skipped per BUG_FIX) |
+| Stages skipped (project-type-correct) | 3 | Refine/Design/Architect — appropriate for a path-change BUG_FIX |
+| Self-correction rounds | 2 | Idea r1->r2 (Solomon save), Dev r1->r2 (Bezalel-cont save) |
+| Independent gate runs of 22/22 | 3 | Bezalel 30.9s, Thomas 30.8s, Moses-Fresh 31.0s — same SHA |
+| Files modified (final scope) | 5 | `package.json`, `playwright.config.ts`, `MasterLayout.tsx`, `README.md`, `node-build.yml` |
+| Commits on branch | 3 | `a16db6e` build/serve.json, `6c83f47` router basename, `a06c574` devlog |
+| Days ahead of self-imposed target | 10–13 | DEC-2026-04-23-001 target 2026-05-15; ready 2026-05-02 |
+| Defects caught pre-merge | 3 of 3 | 100% pre-merge containment; zero production exposure |
+| Hot-lesson validations this run | 4 | grep-tree-first (reinforced), tests-locally-before-push (3rd), workflow-Ezra-cross-ref (3rd, pre-armed), source-PRD-is-spec (held) |
+| New hot lessons added | 1 | "curl URL boundary before tests" (validated 1×) |
+| New canonical decisions added | 2 | DEC-2026-05-05-001 (Option-1+Option-2 pattern), DEC-2026-05-05-002 (Router basename strip) |
+
+Cycle observation: the two self-correction rounds cost real time but each closed cleanly within their stage — no escalation propagated downstream. Idea's cost was paid by Solomon at the architect-review gate; Dev's cost was paid by Bezalel-cont at the local test-runner gate. Neither consumed a full pipeline retry. This is the cheap shape for self-correction.
+
+## Team contributions (every family in front of their own house)
+
+| Role | Alias | House framed |
+|---|---|---|
+| PO (brief author) | Moses | Authored the idea brief; named two of three consumers; fairly characterized the multi-symptom risk class in §2 even before knowing the third consumer existed |
+| Architect | Solomon | Round-1 escalation found the third consumer at `node-build.yml:420`; round-2 review confirmed integration across 5 locations + B6 phantom-consumer scan came up clean |
+| Developer | Bezalel-cont | Round-1 emitted correct disk layout; round-2 layered Option-1+Option-2, dropped `-s` flag, traced the basename bug via Playwright trace screenshot, isolated each fix in its own commit |
+| QA | Thomas | Re-ran the gate firsthand, sensitivity-checked the +14 delta, named the post-merge runbook with explicit USER ownership, did not claim post-merge gates as pre-merge evidence |
+| Tech-writer | Ezra | Cross-referenced the workflow edit per BUG-053-01 (pre-armed as unconditional); release-notes "Memory hot lessons applied" §1 walks the cross-reference; one cosmetic typo to amend (C1) |
+| Ops | Joshua | Verified `deploy:gh-pages` publish-tree validity; production deploy chain confirmed byte-identical pre/post merge |
+| PO (fresh-eyes) | Moses-Fresh | Walked AC-1..AC-9 against disk-truth without sentiment for the brief author; ran the gate a third time; logged C1/C2 hygiene without blocking |
+| Scrum master | Nehemiah | This retrospective |
+
+The brief was fair to its author's limits. The architect-review gate found what the brief author could not see. The developer's first attempt was honest about what it knew and what the test suite revealed. The fresh-eyes PO walked the wall a third time and signed without ceremony. Every family built in front of their own house, and the wall stood.
+
+## Forward-looking signals (next pipeline)
+
+- **Plan-light's empirical-verification step** (proposed Lesson — `curl` the URL boundary at Plan-light, not just at Dev) should be folded into the Plan-light template for the next infra-touching BUG_FIX. The cost is 30 seconds; the value is one fewer Dev round. The Plan-light V-checklist already had a V2 "smoking-gun curl" item — but it was a verification target for Bezalel post-fix, not a pre-commit Plan-light check. Rephrase V2 as "Plan-light runs the pre-fix curl to confirm the failure mode, AND Bezalel runs the post-fix curl to confirm the cure" and the cycle tightens.
+- **Allowed-files list phrasing** should be standardized to "named files + any file proven necessary by a Plan-stage spike or Dev-stage diagnostic, with proof captured in the devlog before the file is touched." The orchestrator template can carry this language. This run's MasterLayout addition was the canonical example of the right behavior; the wrong behavior (silent expansion) would have been the nightmare.
+- **Post-merge attestation pattern is mature.** UAT's runbook (§2) with named owner + calendar target for each gate is the right shape for any change that touches an artifact whose CDN/Pages-side behavior is not reproducible locally. Reuse for any future build-output refactor; the pattern needs no further refinement.
+- **The four-consumer rule is now documented in `OpenDoorWebsiteApp/README.md` §Nested-Prefix-Subdir Convention.** Future reviewers staring at a flat-path bug have a single source of truth. This is the kind of artifact that earns its keep on the *next* BUG_FIX, not this one — measure its value when the next person who needs it does not have to ask the question.
+
+## Comparison to prior runs
+
+- **run-2026-04-22-e2e3 (BUG-053-01):** Workflow-file edit was an unanticipated escalation; this run pre-armed the cross-reference at Idea §4 as **unconditional**, converting a previously-tacit contingency into an explicit plan. Solomon's round-2 review explicitly named this — "the kind of lesson-learned integration that converts pipeline scar tissue into pipeline muscle." Hot lesson 6 ("workflow file changes require Ezra cross-reference") is now validated 3×.
+- **run-2026-05-03-58aa:** "Grep working tree FIRST" was the validated lesson; this run reinforced it by *missing* it once (Moses's third-consumer omission) and *catching it* via the architect-review gate (Solomon's B3). The lesson is now validated 2× by demonstration of both the cost of skipping and the value of catching.
+- **All prior runs:** "Tests run locally before push" — validated 3× including this run; the rule is now a pillar, not a guideline. The 8/22 Round-1 result that was caught locally is the single highest-value moment of this pipeline; without it, CI would have seen a partial fix and the cycle would have lengthened.
+
+## Risk register (post-merge watch)
+
+- **Live demo URL serves a 404 or wrapper page** if `actions/upload-pages-artifact@v3`'s tar-and-publish behavior is incompatible with the new nested-subdir layout. *Mitigation:* SV-001 is the production guard; the demo URL is a manual visual check (UAT runbook step 3); rollback path (`git revert <merge-sha>; git push`) is one revert away. *Probability:* low — the local `serve` evidence in devlog §3.2 mirrors the published-tree shape; `path: ./OpenDoorWebsiteApp/build-gh-pages/OpenDoorPH-website` is the one published from Round 1. *Severity if it materializes:* high (public demo broken until revert).
+- **`stripBasename` edge case on the live URL.** Live GitHub Pages URL is `/OpenDoorPH-website/` (trailing slash); basename is now `/OpenDoorPH-website` (no slash). React Router 6's `stripBasename` accepts both forms uniformly when basename has no trailing slash (verified against source). UAT step 3 is the empirical confirmation. *Probability:* very low. *Severity:* high.
+- **CDN cache lag for the demo.** GitHub Pages CDN may briefly serve the pre-merge artifact. *Mitigation:* the 24h post-merge window in UAT step 3 is generous; Elder visual-check after first cache TTL.
+- **No production risk.** The production deploy chain (`build-files` artifact, `build-prod/`, S3 sync to `opendoorsitebucket`, CloudFront invalidation) is byte-identical pre/post merge per QA execution-log §3 and PO review B5. SV-001 is the automated guard.
+
+## Memory chunk file edits (orchestrator follows up)
+
+The orchestrator should apply these edits in the same turn that closes this retrospective so the next pipeline reads the updated memory from line one:
+
+- `.delivery/memory/index.md` — stage-health row for run-2026-05-05-56bx + new hot lesson 7 ("curl URL boundary before tests"), and reinforce the existing rows for "grep working tree FIRST" (validated 2×) and "tests run locally before push" (validated 3× including this run)
+- `.delivery/memory/stages/idea.md` — Lesson 6 (grep all consumers before §10 recommendation; specifically `package.json`, `playwright.config.ts`, `tsconfig*.json`, `.github/workflows/*.yml` for the build-artifact directory name)
+- `.delivery/memory/stages/development.md` — Lesson 8 (curl URL boundary before test suite, when an infra fix has a verifiable URL boundary)
+- `.delivery/memory/topics/team-decisions.md` — DEC-2026-05-05-001 (Option-1 + Option-2 canonical pattern for `serve` + CRA prefix-env coupling, including the requirement to drop `-s` on prefixed envs), DEC-2026-05-05-002 (React Router v6 `basename` MUST NOT end in trailing slash; apply `.replace(/\/$/, '') || '/'` to any basename derived from `process.env.REACT_APP_*_URI`)
+- `.delivery/memory/archive/run-2026-05-05-56bx.md` — copy of this retrospective for archival reference
+
+> *"And it came to pass, that when our enemies heard thereof, and all the heathen that were about us saw these things, they were much cast down in their own eyes: for they perceived that this work was wrought of our God."* — Nehemiah 6:16. The memory is the wall behind the wall — what one pipeline learned, the next pipeline reads. The orchestrator's job is to keep the courses straight.
+
+> *"Remember me, O my God, for good, according to all that I have done for this people."* — Nehemiah 5:19.
+>
+> The wall stands. Twenty-two of twenty-two march where eight had been walking alone. Every family built in front of their own house — Moses framed his door, Solomon walked the perimeter and named the gate Moses had not seen, Bezalel laid and re-laid the threshold (the first laying was true to the cubits but false to the swing of the door; the second laying was true to both), Thomas tested the latch under oath rather than under faith, Ezra inscribed the lintel and cross-referenced the prior wall's scar, Joshua marched the production camp untroubled and confirmed it byte-identical pre and post, and Moses-Fresh, with eyes that had not seen the brief, walked the wall once more and signed without sentiment for the author.
+>
+> Eleven days early. The hot lessons hold; the new ones are written; the next house will be built sooner because this one was built well.
+>
+> *"And it came to pass, when all our enemies heard thereof, and all the heathen that were about us saw these things, they were much cast down in their own eyes: for they perceived that this work was wrought of our God."* — Nehemiah 6:16. The work was wrought by the team.
+>
+> — Nehemiah, scrum master, run-2026-05-05-56bx

--- a/.delivery/memory/archive/run-2026-05-09-seo1.md
+++ b/.delivery/memory/archive/run-2026-05-09-seo1.md
@@ -1,0 +1,215 @@
+---
+pipeline_id: run-2026-05-09-seo1
+type: FEATURE
+alias_theme: bible
+scrum_master: Nehemiah
+authored: 2026-05-09
+status: DONE
+outcome: ALL_GREEN
+---
+
+# Run Archive — run-2026-05-09-seo1
+
+> "And the people had a mind to work." — Nehemiah 4:6
+> Every family built in front of their own house. The wall stood. The watch was set.
+
+## 1. Header
+
+- **Pipeline ID**: run-2026-05-09-seo1
+- **Type**: FEATURE (no-UI utility — CLI script + scheduled GitHub Actions workflow)
+- **Slice**: Slice C — SEO monitoring + ranked-due reminders
+- **Dates**: 2026-05-09 (single dispatch day)
+- **Alias theme bible**: PO=Moses, SM=Nehemiah, QA=Thomas, DA=Daniel, Architect=Solomon, UX=Luke, UI=Huram, DevOps=Joshua, Developer=Bezalel, Tech-Writer=Ezra
+- **Outcome**: ALL_GREEN — branch ready for merge to master + Jericho first-march per Joshua's release plan §5
+
+## 2. Stages run / skipped
+
+| Stage | Status | Completed | Notes |
+|------:|:------:|:---------:|:------|
+| 1 — Idea | DONE | true | Single PO producer + 2 DoD validators |
+| 2 — Refine | DONE | true | Eval-opt + adversarial r1/r2; PRD v1.0 → v1.1 |
+| 3 — Design | DONE | true | UX + UI no-UI memo; D-R-001 resolved |
+| 4 — Architect | SKIPPED | n/a | FEATURE single-module rule |
+| 5 — Plan | DONE | true | 4 primaries in parallel; 3 self-correction rounds |
+| 6 — Development | DONE | true | 9/9 stories DONE; 62 tests green; both spikes PASS-B |
+| 7 — UAT | DONE | true | Clean DoD r1; 1 non-blocking WARN |
+
+## 3. Per-stage iteration counts
+
+| Stage | Self-correction rounds | DoD rounds | Notes |
+|------:|:---------------------:|:----------:|:------|
+| Idea | 0 | 1 | Clean |
+| Refine | 1 (PRD v1.0→v1.1) | 1 | Adversarial 2 rounds (2/5 → 4/5); evaluator 2 rounds |
+| Design | 1 (Huram reconciliation) | 2 (UX r1 NOT_DONE → all DONE r2) | D-R-001 cross-artifact disagreement |
+| Plan | 3 (max) | 2 (QA r1 NOT_DONE → DONE r2) | Adversarial 3 rounds (2/5 → 3/5 → 3/5) |
+| Development | 0 | 1 | Two spikes resolved as PASS-B before story implementation |
+| UAT | 0 | 1 | Clean DoD on first dispatch |
+
+## 4. Critical saves
+
+The team saved the following before they could become field defects:
+
+1. **Adversarial r1 (Refine) — cron-vs-rank-due silent disarm.** Solomon caught that the scheduled cron would fire `rank-due` daily but the script exits 0 on non-milestone days, leaving the elder with NO signal. Fix: structured `MILESTONE_DAY` marker pattern + workflow grep matching only `30|60|90`. Without this catch, the watchman would have stood his post and seen nothing.
+
+2. **Adversarial r1 (Refine) — third-overdue provenance error.** PRD claimed three overdue items at 2026-05-09; release notes only had two truly overdue (Lighthouse-baseline-2026-05-11 was upcoming-due, not overdue). Solomon caught the +1 miscount.
+
+3. **UX validator r1 (Design) — D-R-001 cross-artifact disagreement.** UX validator round 1 flagged cross-artifact contradiction between Luke's CLI spec and Huram's no-UI memo; Huram self-corrected with a binding Reconciliation block ceding text-surface ownership to Luke.
+
+4. **Adversarial r1 (Plan) — Lesson 4 reprise: test-runner wired 3 ways across 4 artifacts + slice-letter B/C merge-stopper on deploy-plan.** Two merge-stoppers caught before Bezalel ever opened a story.
+
+5. **Adversarial r2 (Plan) — three Lesson-4 species drifts surgically caught**: SM-7 framing in QA artifact; extractNAP shim lock in SM artifact; PASS-B fallback YAML in deploy-plan.
+
+6. **DoD r1 QA (Plan) — PRD §13 file-path lock violation** on DST test name (`dst-boundary` → `rank-due-dst`). Thomas refused to sign DoD until the lock was honored.
+
+7. **Lesson 8 (Dev Step 7) — caught two implementation deviations BEFORE test pass declaration** by curling the boundary first:
+   - canonical: extended to honor FR-CANON-01 posture (b) — sister domains return 200 + `<link rel=canonical>`, no edge redirect
+   - schema: NAP byte-comparison gracefully WARN-skips when `<address>` absent (SPA-rendered)
+
+8. **UAT Lesson 4 honored — BUG-053-01 cross-reference clean.** Ezra-validator ran fresh `git diff master -- .github/workflows/node-build.yml` AND `terraform.yml`; both empty. Production deploy chain unmoved. The single-file attestation pattern from prior runs would have validated only one workflow; this run validated both.
+
+## 5. Locked decisions (D-1..D-11)
+
+| ID | Decision | Rationale |
+|---:|----------|-----------|
+| D-1 | Test runner = Jest (`react-scripts test`); fallback `npm run test:seo` if `.mjs` discovery spike fails | CRA conventional first; PASS-B documented in advance so Plan-Dev handoff has zero ambiguity |
+| D-2 | Slice letter = C | Slice B was already in flight; collision avoided per release-notes ordering |
+| D-3 | MILESTONE_DAY: marker emits `30\|60\|90\|none`; workflow grep matches only `30\|60\|90` | Closes the cron-vs-rank-due silent-disarm trap (critical save #1) |
+| D-4 | Test files = short names (`canonical.test.mjs`, `schema.test.mjs`, `rank-due.test.mjs`) + PRD §13 locks `rank-due-dst.test.mjs` + `rank-due-tz.test.mjs` | File-path discoverability + DST/TZ coverage explicit |
+| D-5 | extractNAP path = `.cjs` shim at `OpenDoorWebsiteApp/scripts/seo-monitor/lib/extractNAPShim.cjs` | Jest+CRA cannot import `.mjs` from outside `src/`; the shim is the bridge |
+| D-6 | SM-7 closure = first manual `workflow_dispatch` on merge day (Jericho first-march) | The march around the wall is the gating event; the cron tick is corroborating evidence only |
+| D-7 | (carry-forward, not re-litigated) | (no formal D-7 entry in Plan summary — D-numbering preserved from carryover) |
+| D-8 | (carry-forward) | (same) |
+| D-9 | Three forbidden-string surfaces rationalized | Source-side guard scope per DEC-2026-05-03-002; no build-side checks |
+| D-10 | `seo-monitor.yml` step-0 invokes `discourse-fidelity-check.sh` | The watchman is checked before he checks others |
+| D-11 | actionlint conditional | Tool-vs-manual review path documented |
+
+## 6. Hot-lesson applications
+
+| Lesson | Where it fired | Outcome |
+|-------:|----------------|---------|
+| Hot 2 (grep-first PRD) | Refine PRD authoring on existing index.html JSON-LD | Avoided duplicate JSON-LD; Refine clean on §schema FR set |
+| Hot 4 (release-notes remediation timelines) | UAT release notes for all 5 known issues | PO DoD signed clean |
+| Hot 5 (tests run locally before push) | Bezalel's 62-test green bar locally on Fedora before any DoD claim | Lesson honored; QA-validator reproduced 0.632s green |
+| Hot 6 (UAT git diff cross-reference) | Ezra-validator on TWO workflows (node-build.yml + terraform.yml) | Validates Lesson 4; new species (multi-workflow) noted below |
+| Hot 7 (curl boundary before tests) | Bezalel Step 7 stdout verification before test pass declaration | Caught 2 implementation deviations in canonical + schema |
+| Plan Lesson 4 (cross-artifact wiring drift) | Adversarial r1 + r2 in Plan | Caught 5 species across two rounds |
+| UAT Lesson 4 (git-show against runbook) | Ezra-validator UAT DoD | Clean — validates lesson + extends to multi-workflow case |
+
+## 7. New lessons identified (proposed for memory chunks)
+
+The orchestrator should route these to the named chunks. I list them here verbatim so they can be pasted in.
+
+### For `stages/refine.md` — NEW Lesson
+
+> **Insight**: When the PRD claims to "close N overdue items", verify N against the SOURCE release notes carefully — Lighthouse-baseline-2026-05-11 was upcoming-due, not overdue, on 2026-05-09. Adversarial r1 caught a +1 miscount. Author's checklist: for every overdue claim, paste the release-notes target date AND today's date side by side in the PRD draft for the adversarial reviewer.
+> **Validated**: 1
+> **Last**: run-2026-05-09-seo1
+
+### For `stages/plan.md` — NEW Lesson 5
+
+> **Insight**: Lesson 4 (cross-artifact wiring drift) keeps recurring. After the first round of 4 parallel Plan primaries, ALWAYS dispatch a consensus facilitator + adversarial reviewer BEFORE DoD. The two together caught 5 Lesson-4 species drifts in this run that DoD alone would have missed (test-runner wired 3 ways, slice letter B/C, SM-7 framing in QA, extractNAP shim lock in SM, PASS-B fallback YAML in deploy-plan). Without this pre-DoD adversarial pass, the merge-stoppers would have surfaced at QA DoD r1 — costing one extra full DoD round.
+> **Validated**: 1
+> **Last**: run-2026-05-09-seo1
+
+### For `stages/development.md` — NEW Lesson 9
+
+> **Insight**: Plan-Dev handoff spikes for unverified runtime assumptions (here: Jest+`.mjs` discovery, lhci+Fedora) MUST run BEFORE the first story implementation. Both spikes in this run fell to PASS-B and the contingency saved approximately 2 sittings of rework — `.mjs` discovery would have failed in S-09's first test write, and lhci would have failed in S-04's first execution. Author's checklist: every Plan handoff with a "PASS-A clean / PASS-B fallback" decision must list the spike as a Day-0 deliverable, not Day-N investigation.
+> **Validated**: 1
+> **Last**: run-2026-05-09-seo1
+
+### For `stages/uat.md` — VALIDATE Lesson 4 (extend with multi-workflow species)
+
+> **Increment Validated count from 1 → 2.**
+> **Update Last to**: run-2026-05-09-seo1
+> **Add to Insight**: When DevOps validates own-workflow non-interference, run `git diff master -- .github/workflows/<other>.yml` for EACH existing workflow (here: node-build.yml AND terraform.yml). Single-file BUG-053-01 attestation misses the second. The 60-second cost scales linearly with workflow count and prevents an entire category of regression.
+
+### For `topics/team-decisions.md` — Three NEW decisions
+
+- **DEC-2026-05-09-001: SEO monitoring utility runner**
+  - **Decision**: Jest via `react-scripts test`; fallback `npm run test:seo` direct Jest if CRA refuses `.mjs` outside `src/` (PASS-B fired in this run).
+  - **Why**: CRA conventional first; documented fallback in Plan removes runtime ambiguity at Plan-Dev handoff.
+  - **Made by**: Plan orchestrator decision D-1; PASS-B confirmed by Bezalel at Dev Step 1.
+  - **Reversibility**: Trivial (drop `test:seo` script + `jest.config.cjs` once CRA stops refusing or scripts move under `src/`).
+  - **Pipeline run**: run-2026-05-09-seo1
+
+- **DEC-2026-05-09-002: lhci on Fedora 43 requires CHROME_PATH**
+  - **Decision**: `lhci` on Fedora 43 (no system Chromium) requires `CHROME_PATH` env var pointing at the Playwright Chromium binary (e.g., `/var/home/<user>/.cache/ms-playwright/chromium-1217/chrome-linux64/chrome`).
+  - **Why**: PASS-A clean install relies on a system Chromium that is not present on Fedora 43; the Playwright binary is already on disk from existing E2E work.
+  - **Made by**: Plan orchestrator spike 1.2; PASS-B confirmed by Bezalel at Dev Step 4.
+  - **Reversibility**: Trivial (drop env var once Fedora packages bundled Chromium).
+  - **Pipeline run**: run-2026-05-09-seo1
+
+- **DEC-2026-05-09-003: SM-7 closure mechanism**
+  - **Decision**: SM-7 closure mechanism = first manual `workflow_dispatch` on merge day (Jericho first-march); cron tick is corroborating evidence, not the gating event.
+  - **Why**: Cron alone leaves a window where the workflow is "merged but unproven"; the manual march closes that window deterministically and gives the elder a known clock for the watch.
+  - **Made by**: Plan orchestrator decision D-6.
+  - **Reversibility**: Trivial (allow cron-only closure once two consecutive cron ticks have produced clean stdout markers).
+  - **Pipeline run**: run-2026-05-09-seo1
+
+## 8. Defect count
+
+### By stage
+
+| Stage | Self-correction defects | DoD defects | Adversarial findings | Total |
+|------:|:-----------------------:|:-----------:|:---------------------:|:-----:|
+| Idea | 0 | 0 | n/a | 0 |
+| Refine | 6 (eval-opt r1) | 0 | 2 (cron-disarm, +1 miscount) | 8 |
+| Design | 1 (D-R-001) | 1 (UX r1) | n/a | 2 |
+| Plan | 11 (D-1..D-11 absorption) | 1 (PRD §13 file-path lock) | 9 (5 r1 + 3 r2 + 1 r3) | 21 |
+| Development | 0 | 0 | 2 (Lesson 8 stdout deviations, caught self) | 2 |
+| UAT | 0 | 0 (1 WARN, non-blocking) | n/a | 0 |
+| **Totals** | **18** | **2** | **13** | **33** |
+
+### By category
+
+- **Cross-artifact wiring drift (Lesson 4 species)**: 5 (Plan)
+- **Provenance / counting errors**: 1 (Refine, +1 overdue miscount)
+- **Silent-failure trap closures**: 1 (Refine, cron-vs-rank-due)
+- **File-path lock violations**: 1 (Plan, PRD §13)
+- **Implementation drift caught by stdout verification**: 2 (Dev, canonical + schema)
+- **Cross-artifact disagreement**: 1 (Design D-R-001)
+- **Self-correction (PRD/primary revision)**: 18 (within self-correction rounds)
+- **Cosmetic non-blocking WARNs**: 5 (test-strategy stale ref; PR description D-11 actionlint; qa execution-log stale; AC-33/35 grep extension; release-notes header §9 cross-ref)
+
+**Defects per story (Dev only)**: 2 / 10 = 0.20 (under 0.3 target)
+
+## 9. What went well (5)
+
+1. **Two PASS-B spikes executed before any story implementation.** Plan handed Dev a clear "if-this-then-that" runbook and Bezalel never had to backtrack. The `npm run test:seo` + `jest.config.cjs` and the `CHROME_PATH=Playwright-binary` patterns slotted in cleanly.
+2. **Adversarial-before-DoD pattern at Plan caught 5 Lesson-4 species drifts in one round.** The combined consensus + adversarial pass turned what would have been 2-3 DoD rounds into 1 self-correction round + 1 clean DoD.
+3. **Lesson 8 honored at Dev Step 7 — the curl-the-boundary-first habit caught two implementation deviations BEFORE Bezalel claimed test pass.** Both were silent semantic issues that would have masqueraded as test bugs without the boundary check.
+4. **UAT Lesson 4 extended to multi-workflow attestation.** Ezra-validator's two-workflow git-diff (node-build.yml + terraform.yml) is the clean form of the lesson. Will harden the chunk.
+5. **All 4 UAT validators DONE on first dispatch.** PO + QA + DevOps + Tech-Writer all green. The only WARNs were truly non-blocking (cosmetic + grep extension scheduled for 2026-05-15).
+
+## 10. What did NOT go well (5 growth edges)
+
+1. **Plan needed 3 self-correction rounds (the max).** Adversarial round-3 still found a residual line in the SM artifact. The cross-artifact wiring drift species needs a structural mitigation, not a per-run cleanup. Lesson 5 above is the structural answer.
+2. **Refine PRD v1.0 had a +1 overdue miscount.** Provenance fields in the PRD draft (today's date alongside each "overdue" claim's target date) would have prevented Solomon from spending a round on it.
+3. **Design needed UX validator round 1 (NOT_DONE) to catch D-R-001.** UI and UX produced contradictory text-surface ownership claims; the cross-artifact reconciliation should have happened at primary-author time, not validator-time.
+4. **Cosmetic carryovers accumulated across stages without cleanup.** test-strategy §10 row 2 stale `ci-activation-plan.md` reference appeared in Stage 5 carryovers, again in Stage 6 carryovers, again in Stage 7 carryovers — never cleaned. The team should institute a "cosmetic-cleanup story" at Plan when 2+ cosmetics accumulate.
+5. **The single-workflow BUG-053-01 attestation pattern was the prior norm.** It would have missed the second workflow this run if Ezra-validator hadn't expanded the check on his own initiative. The lesson chunk needs the multi-workflow extension explicitly so future runs do not regress.
+
+## 11. Action items for the team
+
+| # | Action | Owner | Due |
+|---:|--------|-------|-----|
+| A1 | Update `stages/plan.md` with new Lesson 5 (consensus + adversarial BEFORE DoD after r1 of 4 parallel primaries) | Memory orchestrator | Before next run |
+| A2 | Update `stages/refine.md` with new Lesson on overdue-count provenance check (paste target+today dates side-by-side) | Memory orchestrator | Before next run |
+| A3 | Update `stages/development.md` with new Lesson 9 (Plan-Dev handoff spikes Day-0, not Day-N) | Memory orchestrator | Before next run |
+| A4 | Update `stages/uat.md` Lesson 4 — increment Validated 1→2, extend Insight with multi-workflow git-diff requirement | Memory orchestrator | Before next run |
+| A5 | Add three DEC-2026-05-09-001/002/003 entries to `topics/team-decisions.md` | Memory orchestrator | Before next run |
+| A6 | At Plan, when 2+ cosmetic carryovers exist, add an explicit "cosmetic-cleanup" story so they get picked up rather than re-noted | SM (Nehemiah) standing rule | Next Plan stage |
+| A7 | At Refine PRD authoring, add "today's date" header and paste each release-notes target date next to its "overdue" claim | PO (Moses) template change | Next Refine |
+| A8 | At Design, when UX and UI primaries name overlapping text surfaces, require an explicit "ownership matrix" row in BOTH artifacts | UX/UI primary template | Next Design |
+| A9 | Land deferred grep extension AC-33/AC-35 to `no-philippines.test.mjs` per UAT carryover | Bezalel | 2026-05-15 |
+| A10 | Land cosmetic test-strategy §10 row 2 reference cleanup (`ci-activation-plan.md` → `deploy-plan.md`) | Thomas | Next maintenance pass |
+
+## 12. Retrospective signature
+
+> Sealed by **Nehemiah**, Scrum Bag and servant of the watch.
+> Dispatch-day: 2026-05-09.
+> Run ID: run-2026-05-09-seo1.
+> "So built we the wall; and all the wall was joined together unto the half thereof: for the people had a mind to work."
+> — Nehemiah 4:6
+
+The wall stands. The watchman is set. The march is appointed. Let the next family build in front of their own house.

--- a/.delivery/memory/index.md
+++ b/.delivery/memory/index.md
@@ -1,23 +1,26 @@
 # Memory Index
 
-## Stage Health (last 7 runs)
+## Stage Health (last 10 runs)
 | Stage | First-Try Pass Rate | Notes |
 |-------|-------------------|-------|
-| Idea | 100% | Clean pass all runs |
-| Refine | 83% | ev3k: eval-opt revision for edge cases; fb3n: PH typo |
-| Design | 100% | ga4x localStorage fix validated; ev3k consistency clean |
-| Plan | 100% | Clean pass all runs |
-| Development | 86% | ev3k: missing test coverage caught by QA DoD round 1 |
-| UAT | 86% | bf7w: PO rejected missing remediation timeline; ev3k: clean |
+| Idea | 90% | seo1: clean (1 round, Solomon WARN deferred to Plan); 56bx: 1 self-correction (3rd consumer caught); 58aa: clean |
+| Refine | 70% | seo1: 1 self-correction round (adversarial 2/5 → 4/5; cron-vs-rank-due + three-overdue provenance); 58aa: 3 PRD rounds + DoD self-correction |
+| Design | 100% | seo1: slim no-UI (1 self-correction for D-R-001 reconciliation; both rounds clean); 58aa: clean |
+| Plan | 60% | seo1: 3 self-correction rounds (Lesson-4 reprise — test-runner wired 3 ways, slice letter B/C, MILESTONE_DAY 3 forms, file names, extractNAP path); 58aa: 2 self-correction rounds; 56bx: light Plan clean |
+| Development | 80% | seo1: clean DoD r1 (62/62 tests green; both Plan-Dev spikes PASS-B); 58aa: 124/124 + Story 5 CODE_COMPLETE-deferred; 56bx: 1 self-correction; e2e3: 1 self-correction |
+| UAT | 90% | seo1: clean DoD r1 (BUG-053-01 cross-reference clean for both node-build.yml AND terraform.yml); 58aa: clean DoD r1; bf7w: PO rejected missing dates |
 
-## Hot Lessons (top 5)
-1. **"PH" in OpenDoorPH = Pleasant Hill, NOT Philippines.** Never reference Philippines in copy, labels, or alt-text. See `topics/project-facts.md`.
-2. Cross-artifact consistency checks work when institutionalized — ga4x identified, ev3k validated (2x).
-3. Release notes must include remediation timelines for ALL known issues — PO DoD rejects without dates (3x validated).
-4. Test-writing without test-running produces CODE_COMPLETE. First CI run may surface issues code review can't catch.
-5. Front-load edge case specificity at Idea (empty states, keyboard nav, timezone) to compress Refine eval-opt cycles.
+## Hot Lessons (top 7)
+1. **"PH" in OpenDoorPH = Pleasant Hill, NOT Philippines.** Never reference Philippines in copy, labels, or alt-text. See `topics/project-facts.md`. Validated 4x.
+2. **When authoring an "add X" PRD on an existing codebase, grep the working tree for X FIRST.** 60 seconds at PRD-time saves 2 rounds of Refine rework. Validated 1x (58aa).
+3. **Cross-artifact consistency checks work when institutionalized.** Validated 4x (ga4x identified, ev3k 2x, 58aa Plan-stage 3x, seo1 Plan-stage 5 Lesson-4 species drifts caught).
+4. **Release notes must include remediation timelines for ALL known issues.** PO DoD rejects without dates. Validated 5x (most recent: seo1).
+5. **Tests run locally before push; verify runtime exists before writing tests.** Validated 3x. Plan-Dev spikes (Lesson 9 added in seo1) MUST run before first-story implementation.
+6. **After a build-artifact dir rename OR workflow file edit, UAT tech-writer must cross-reference `git show <sha> --stat` (or `git diff master -- <each-existing-workflow>`) before signing DoD.** Sub-rule: when adding a NEW workflow, verify EVERY existing workflow's diff is empty, not just node-build.yml. Validated 4x (e2e3, 58aa, 56bx, seo1).
+7. **For infra fixes / new utilities with verifiable URL boundaries (serve/proxy/CDN/curl), curl the boundary BEFORE running the test suite.** A 30-second curl can distinguish "test setup wrong" from "test failure for unrelated reason." Validated 2x (56bx, seo1 — caught 2 implementation deviations in seo1 Step 7 before test pass declaration).
 
 ## Topic Pointers
-- Project facts (church identity, domains, stack): `topics/project-facts.md` **← read for any copy/labels/alt-text work**
-- Stage lessons: `stages/idea.md`, `stages/refine.md`, `stages/design.md`, `stages/plan.md`, `stages/development.md`, `stages/uat.md`
-- Archive: `archive/run-2026-04-04-fx8s.md`, `archive/run-2026-04-04-tw3p.md`, `archive/run-2026-04-05-hc1q.md`, `archive/run-2026-04-06-bf2x.md`, `archive/run-2026-04-08-cr1t.md`, `archive/run-2026-04-08-fb3n.md`, `archive/run-2026-04-10-bf7w.md`, `archive/run-2026-04-10-ga4x.md`, `archive/run-2026-04-12-ev3k.md`, `archive/run-2026-04-14-dv2k.md`
+- Project facts (church identity, domains, stack, **canonical = opendoorph.org**): `topics/project-facts.md` **← read for any copy/labels/alt-text/schema work**
+- Team decisions: `topics/team-decisions.md` (DEC-2026-05-09-001/002/003 added seo1)
+- Stage lessons: `stages/idea.md`, `stages/refine.md` (Lesson 4+5 added seo1), `stages/design.md`, `stages/plan.md` (Lessons 5+6 added seo1; L4 validated 2x), `stages/development.md` (Lesson 9 added seo1; L8 validated 2x), `stages/uat.md` (L4 sub-rule added seo1; validated 4x)
+- Archive: `archive/run-2026-04-04-fx8s.md`, `archive/run-2026-04-04-tw3p.md`, `archive/run-2026-04-05-hc1q.md`, `archive/run-2026-04-08-fb3n.md`, `archive/run-2026-04-10-bf7w.md`, `archive/run-2026-04-10-ga4x.md`, `archive/run-2026-04-12-ev3k.md`, `archive/run-2026-04-14-dv2k.md`, `archive/run-2026-04-22-e2e3.md`, `archive/run-2026-05-03-58aa.md`, `archive/run-2026-05-05-56bx.md`, `archive/run-2026-05-09-seo1.md`

--- a/.delivery/memory/stages/development.md
+++ b/.delivery/memory/stages/development.md
@@ -29,3 +29,18 @@
 - **Insight**: QA DoD catches real test coverage gaps even when code review passes. Empty-state tests and keyboard navigation tests are commonly missed categories. Always include empty-array/empty-state and full keyboard interaction tests in the initial implementation.
 - **Validated**: 1
 - **Last**: run-2026-04-12-ev3k
+
+## Lesson 7
+- **Insight**: When a fix renames a build artifact directory (BUILD_PATH, output dir, dist/ → out/, etc.), the dev-stage validation MUST grep the entire repo (workflows, README, deploy scripts) for the old name. Plan-stage risk lists tend to name deploy:gh-pages but miss CI/AWS chain references. Caught only at UAT round 1 by tech-writer cross-referencing commit content against on-disk workflow.
+- **Validated**: 1
+- **Last**: run-2026-04-22-e2e3
+
+## Lesson 8
+- **Insight**: When an infra fix has a verifiable URL boundary (serve / proxy / CDN behavior), curl the boundary BEFORE running the test suite. A 30-second curl can distinguish "test setup wrong" from "test failure for unrelated reason." In run-2026-05-05-56bx, Bezalel's round-1 fix landed the right disk layout but tests still returned 8/22 — a curl on `localhost:3101/OpenDoorPH-website` revealed `serve` was returning a directory listing, not React's index.html. The curl pre-check would have caught the partial fix without burning a full Playwright run.
+- **Validated**: 2
+- **Last**: run-2026-05-09-seo1 (caught 2 implementation deviations: canonical body-fetch posture; schema NAP-skip on absent `<address>`)
+
+## Lesson 9
+- **Insight**: When the Plan stage names a runtime assumption that's unverified (Jest+`.mjs` discoverability, lhci+Fedora Chromium availability), that assumption MUST be cleared by a Plan-Dev handoff spike BEFORE first-story implementation begins — not validated as part of the first story. In run-2026-05-09-seo1, both spikes (S-09 AC-6 sentinel + S-04 AC-9 lhci) fell to PASS-B; running them first meant the contingency (test:seo script + CHROME_PATH env var) was already in the design when implementation started. Without the spike-first discipline, S-01 would have shipped with an undiscoverable test layer.
+- **Validated**: 1
+- **Last**: run-2026-05-09-seo1

--- a/.delivery/memory/stages/idea.md
+++ b/.delivery/memory/stages/idea.md
@@ -19,3 +19,13 @@
 - **Insight**: Front-loading edge case specificity at Idea (empty states, keyboard nav, timezone handling) compresses the Refine eval-opt cycle. When the Idea brief is vague on edge cases, the PRD inherits those gaps and QA catches them, costing a revision round.
 - **Validated**: 1
 - **Last**: run-2026-04-12-ev3k
+
+## Lesson 5
+- **Insight**: For multi-symptom infrastructure bugs, the Idea stage's hypothesis confidence should default to 2-3/5 with explicit alternative root causes listed. A 4/5 confidence rating with only one named root cause biases Plan and Dev toward the named hypothesis and lets a hidden second bug slip through to UAT. Issue #53 had two root causes (race + prefix-mismatch); only the race was named.
+- **Validated**: 1
+- **Last**: run-2026-04-22-e2e3
+
+## Lesson 6
+- **Insight**: For infra changes touching a build-artifact directory name (BUILD_PATH, dist/, out/, etc.), grep ALL of `package.json`, `playwright.config.ts`, `tsconfig*.json`, and `.github/workflows/*.yml` for the dir name BEFORE writing the §10 recommendation. Idea-stage architecture sweep must produce a complete consumer enumeration; downstream stages plan an atomic update. In run-2026-05-05-56bx Moses missed the `demo-deploy` job in node-build.yml:420; Solomon's Architect DoD caught it.
+- **Validated**: 1
+- **Last**: run-2026-05-05-56bx

--- a/.delivery/memory/stages/plan.md
+++ b/.delivery/memory/stages/plan.md
@@ -2,5 +2,30 @@
 
 ## Lesson 1
 - **Insight**: Light Plan (single story, SM+QA DoD only) is sufficient for single-resource infrastructure fixes. All passed first attempt with no rework needed.
+- **Validated**: 2
+- **Last**: run-2026-04-22-e2e3
+
+## Lesson 2
+- **Insight**: Plan-stage risk-list discipline must include a "where does the renamed thing flow downstream?" sweep. For BUG-053-01, the risk list named deploy:gh-pages but missed CI workflow upload-artifact / aws s3 sync chains and README references. Adding a "rename grep" step would catch these in Plan, not UAT.
 - **Validated**: 1
-- **Last**: run-2026-04-04-fx8s
+- **Last**: run-2026-04-22-e2e3
+
+## Lesson 3
+- **Insight**: Cross-artifact build-path consistency is a high-frequency Plan-stage drift. PO + SM + QA + DevOps each reference build dirs; if any has typos or stale names (e.g., `build-root`/`build-gh` vs the actual `build-prod`/`build-gh-pages`/`build-custom`/`build-deep` from `package.json`), the gap won't be caught until DevOps DoD validates against `package.json`. Mitigation: when authoring a Plan primary, include a "verify all paths against package.json" line in the prompt. Caught in run-2026-05-03-58aa Plan DoD round 2 (DevOps B7).
+- **Validated**: 1
+- **Last**: run-2026-05-03-58aa
+
+## Lesson 4
+- **Insight**: "FR/Test wired to CI vs UAT vs attestation" must agree across stories.md, test-strategy.md, and deploy-plan.md. A single source of truth (the PRD's FR text) is not sufficient if downstream artifacts paraphrase the wiring differently — adversarial caught run-2026-05-03-58aa with FR-06 wired three different ways across the four Plan artifacts. Cross-reference at Plan DoD: every CI/UAT/attestation claim should match exactly across primaries.
+- **Validated**: 2
+- **Last**: run-2026-05-09-seo1
+
+## Lesson 5
+- **Insight**: After the first round of 4 parallel Plan primaries, ALWAYS dispatch a CONSENSUS facilitator + ADVERSARIAL reviewer BEFORE DoD — the two together caught 5 Lesson-4 species drifts in run-2026-05-09-seo1 (test-runner wired 3 ways, slice letter B/C, MILESTONE_DAY regex 3 forms, test file names long vs short, extractNAP path 3 stances) that DoD alone would have missed. Adversarial confidence trajectory: 2/5 → 4/5 → 3/5 (last round caught 3 NEW surgical drifts). Consensus + adversarial in parallel after Plan primaries is now a standing pattern.
+- **Validated**: 1
+- **Last**: run-2026-05-09-seo1
+
+## Lesson 6
+- **Insight**: When a PRD §13 "file path lock" exists, every Plan artifact (and every test file Bezalel later authors) must use the locked path BYTE-EXACT. Renames silently break the lock. In run-2026-05-09-seo1, test-strategy r1 used `tz-runner-utc.test.mjs` and `dst-boundary.test.mjs` while PRD §13 locked `rank-due-tz.test.mjs` and `rank-due-dst.test.mjs`. Both were caught at adversarial r2 + DoD r1 QA. Fix: Plan DoD validators must explicitly include a "PRD §13 path-lock byte-equality check" gate.
+- **Validated**: 1
+- **Last**: run-2026-05-09-seo1

--- a/.delivery/memory/stages/refine.md
+++ b/.delivery/memory/stages/refine.md
@@ -9,3 +9,18 @@
 - **Insight**: When user provides feedback that changes scope at Refine checkpoint (e.g., plan-only → plan+approve+apply), update the PRD immediately and re-validate before proceeding. Don't carry the change as informal context.
 - **Validated**: 1
 - **Last**: run-2026-04-04-tw3p
+
+## Lesson 3
+- **Insight**: When authoring an "add X" or "ship X" PRD on an existing codebase, run a literal grep / file-read for X in the working tree BEFORE writing the problem statement. The adversarial reviewer will catch this in 60 seconds — better to catch it during PRD authoring than burn 2 PRD rounds reframing as "audit + reconcile". Run-2026-05-03-58aa adversarial round 1 caught this with confidence 1/5: the PRD declared "site lacks JSON-LD entirely" but `OpenDoorWebsiteApp/public/index.html` already shipped a Church/LocalBusiness block with a different canonical. Without the catch, the slice would have produced duplicate `<script type="application/ld+json">` blocks AND silently flipped canonical from .org to .info.
+- **Validated**: 1
+- **Last**: run-2026-05-03-58aa
+
+## Lesson 4
+- **Insight**: When the PRD claims to "close N overdue items", verify N against the SOURCE release notes by date arithmetic, not by assumption. In run-2026-05-09-seo1, the PRD round 1 declared "three overdue items" but slice-A release notes showed only TWO were overdue at 2026-05-09 (Demo URL 2026-05-06, Production curl 2026-05-05); Lighthouse baseline 2026-05-11 was upcoming-due. Adversarial r1 caught the +1 miscount. Correct framing: "two overdue + one upcoming-due."
+- **Validated**: 1
+- **Last**: run-2026-05-09-seo1
+
+## Lesson 5
+- **Insight**: For monitoring/scheduled-job features, validate that the schedule and the per-run logic don't mutually disarm. In run-2026-05-09-seo1, PRD round 1 had `rank-due` exit 0 on non-milestone days AND the cron run `all`, which would silently emit NO signal except on day 30/60/90 — the elder would think the workflow was broken. Fix: structured `MILESTONE_DAY=` marker emitted always (with `=none` on non-milestone days); workflow grep matches only `30|60|90`. Adversarial r1 caught this at confidence 2/5.
+- **Validated**: 1
+- **Last**: run-2026-05-09-seo1

--- a/.delivery/memory/stages/uat.md
+++ b/.delivery/memory/stages/uat.md
@@ -14,3 +14,8 @@
 - **Insight**: Stakeholder-removed checkpoints should be logged, not debated. Record the decision in the retrospective with the tradeoff noted. The team continues with maximum diligence and self-policing quality. For low-risk projects (church website), this is acceptable. For compliance/sensitive projects, flag the risk explicitly.
 - **Validated**: 1
 - **Last**: run-2026-04-12-ev3k
+
+## Lesson 4
+- **Insight**: UAT tech-writer DoD round 1 should explicitly cross-reference the runbook's "files in commit" claim against `git show <sha> --stat`. This catch can prevent production-deploy regressions invisible to dev/qa/architect DoD because they validate the new code path, not the unchanged-but-now-stale CI deploy path. Cost: 30 seconds of `git show`. Save: a wiped S3 bucket. **Sub-rule (run-2026-05-09-seo1)**: when the slice adds a NEW workflow file, run `git diff master -- .github/workflows/<each-existing-workflow>.yml` for EVERY existing workflow (not just node-build.yml). In this run, both node-build.yml AND terraform.yml were verified empty.
+- **Validated**: 4
+- **Last**: run-2026-05-09-seo1

--- a/.delivery/memory/topics/team-decisions.md
+++ b/.delivery/memory/topics/team-decisions.md
@@ -1,0 +1,65 @@
+# Topic: Team Decisions
+
+## DEC-2026-04-23-001: Issue #53 PR gate scope
+- **Decision**: Narrow `test:e2e:pr` to a11y + Root Domain via `--grep-invert "GitHub Pages|Custom Path"`. Defer gh-pages + Custom Path coverage via follow-up issue.
+- **Why**: `npx serve -s` does not mount the bundle at the embedded PUBLIC_URL prefix. Three remediation candidates (serve.json rewrites / pre-staged subdirs / inline express) each carry meaningful additional surface area; defer-with-follow-up preserves Hot Lesson 4 (no aspirational green ships).
+- **Made by**: elder, at Stage 6 escalation
+- **Reversibility**: Trivial (drop the `--grep-invert` once the prefix-mismatch is solved)
+- **Target sprint to restore**: 2026-05-15
+- **Pipeline run**: run-2026-04-22-e2e3
+
+## DEC-2026-05-03-001: OpenDoorPH canonical domain
+- **Decision**: `https://opendoorph.org/` is the canonical site. The other three domains (`opendoorph.info`, `opendoorph.net`, `opendoorph.com`) redirect to `.org`. Affects: schema `url`, `<link rel=canonical>`, sitemap.xml, robots.txt, GBP "website" field, citation listings.
+- **Why**: Existing `OpenDoorWebsiteApp/public/index.html` already shipped JSON-LD with `.org` canonical and `<link rel=canonical>` to `.org`. PRD round 1 of run-2026-05-03-58aa declared `.info`; adversarial caught the contradiction at confidence 1/5; elder ratified `.org` as the deployed canonical. Print materials and the live site agree.
+- **Made by**: elder, at Stage 2 escalation
+- **Reversibility**: Trivial (CDN/redirect change; would also require schema and rel=canonical updates)
+- **Pipeline run**: run-2026-05-03-58aa
+
+## DEC-2026-05-03-002: Forbidden-string regression guard scope
+- **Decision**: The `philippines` / `pleasant hill interdenom` / `herbert lowrey` regression guard runs **source-side** (`OpenDoorWebsiteApp/src/` + `OpenDoorWebsiteApp/public/`), NOT against build outputs. Implementation: `OpenDoorWebsiteApp/scripts/check-forbidden-strings.sh` invoked by CI in `node-build.yml`.
+- **Why**: Build outputs are deterministic transforms of source; source coverage covers all 4 build envs uniformly. CI doesn't run all 4 builds (only `build:prod`), so a build-side check would either skip envs (silent gap) or fail-pre-condition (false-fail).
+- **Made by**: PO ruling, at Plan DoD round 2 (driven by DevOps B7 finding)
+- **Reversibility**: Trivial (move the grep target back to build dirs if CI ever runs all 4 builds)
+- **Pipeline run**: run-2026-05-03-58aa
+
+## DEC-2026-05-05-001: serve + CRA prefix-env coupling pattern
+- **Decision**: For CRA builds with non-empty `PUBLIC_URL` served via `serve` (or `serve-handler`), the canonical fix is **Option-1 + Option-2 layered**: nest the build output under the prefix path (`BUILD_PATH=./<dir>/<prefix>/`) AND emit a `serve.json` at the served root with rewrites mapping `/<prefix>{,/**}` → `/<prefix>/index.html` and `directoryListing: false`.
+- **Why**: Option-2 alone (nested subdirs) is necessary but not sufficient — `serve -s <root>` returns directory listings for paths that match prefix subdirs instead of auto-serving the nested `index.html`. The asset paths (`/<prefix>/static/...`) work after Option-2 alone, but the initial route lands on a listing and React never mounts.
+- **Made by**: PO ruling, run-2026-05-05-56bx Stage 6 round 2 (Bezalel-cont's curl diagnostic + layered fix)
+- **Reversibility**: Trivial (revert the serve.json emission step in package.json)
+- **Pipeline run**: run-2026-05-05-56bx
+
+## DEC-2026-05-05-002: React Router basename trailing-slash invariant
+- **Decision**: `react-router-dom@6.x`'s `<Router basename={...}>` MUST be passed a value that does NOT end with a trailing slash. Apply `.replace(/\/$/, '') || '/'` to any basename derived from `process.env.REACT_APP_*_URI` (which is conventionally trailing-slashed in CRA project configs).
+- **Why**: React Router's `stripBasename` returns `null` for URLs that don't match the basename including its trailing slash. With basename `/OpenDoorPH-website/`, the bare-prefix URL `/OpenDoorPH-website` (no trailing slash, the form Playwright and many users actually visit) doesn't match — no routes resolve, blank page, link locators fail. The strip-trailing-slash makes basename `/OpenDoorPH-website` which matches both forms.
+- **Made by**: Bezalel-cont diagnosis at Stage 6 round 2; PO ruling at UAT acceptance
+- **Reversibility**: Trivial 1-line revert in `MasterLayout.tsx`
+- **Pipeline run**: run-2026-05-05-56bx
+
+## DEC-2026-05-03-003: NAP byte-match contract scope
+- **Decision**: NAP byte-equality test scope is `streetAddress + postalCode + telephone (if present)`. `addressLocality`, `addressRegion`, and `name` are advisory checks that emit `console.warn` but do NOT fail the test (FR-05.5/FR-05.6 in the PRD).
+- **Why**: Brand-suffix variation ("Open Door Full Gospel Church Of Pleasant Hill" on Footer/LocationPage vs "Open Door Full Gospel Church" in schema) and state-name variation ("Pleasant Hill, Missouri" on LocationPage vs "MO" in schema) are real but reflect display preferences, not data drift. The Address+Phone scope captures the citation-relevant signal without forcing brand-text reconciliation.
+- **Made by**: PO ruling, at Refine DoD round 1 (driven by Thomas-Fresh's LocationPage Missouri/MO finding)
+- **Reversibility**: Moderate (would require expanding test scope and reconciling brand text — likely a separate Issue if the elder decides the brand should match the schema name exactly)
+- **Pipeline run**: run-2026-05-03-58aa
+
+## DEC-2026-05-09-001: SEO monitor test runner = Jest via react-scripts; fallback `npm run test:seo`
+- **Decision**: The seo-monitor utility's tests run under Jest (the existing CRA convention). Because CRA's `react-scripts test` does not pick up `*.test.mjs` outside `src/`, the canonical invocation is `npm run test:seo` → `jest --config OpenDoorWebsiteApp/scripts/seo-monitor/jest.config.cjs`. The 8 added package.json script keys = 7 `seo:*` (umbrella + 6 per-subcommand) + 1 `test:seo` (non-`seo:*` namespace, preserves the seven-`seo:*` invariant).
+- **Why**: Plan-Dev sentinel spike (S-09 AC-6) confirmed PASS-B branch fired (CRA refuses .mjs outside src/). Adding the dedicated Jest config under the script directory keeps test discovery deterministic without ejecting CRA.
+- **Made by**: Orchestrator decision D-1 at Plan self-correction round 1; ratified by Plan-Dev spike outcome
+- **Reversibility**: Moderate (would require migrating to node:test or a different runner)
+- **Pipeline run**: run-2026-05-09-seo1
+
+## DEC-2026-05-09-002: lhci on Fedora 43 requires CHROME_PATH env var
+- **Decision**: On Fedora 43 dev box (the elder's environment), `npx lhci collect` fails Chromium discovery by default. Workaround: `CHROME_PATH=/var/home/meconnelly/.cache/ms-playwright/chromium-1217/chrome-linux64/chrome npx lhci ...`. Documented in the utility README + cli-ux-spec FR-LH-05 diagnostic message. CI runner (ubuntu-latest) does NOT need the env var.
+- **Why**: Plan-Dev spike (S-04 AC-9) PASS-B branch fired. The elder's Fedora doesn't ship a system Chromium; Playwright's bundled Chromium binary is the cleanest available executable.
+- **Made by**: Bezalel diagnosis at Stage 6 spike 1.2; documented across release-notes + utility README + cli-ux-spec
+- **Reversibility**: Trivial (`sudo dnf install chromium` would unblock without env var; documented as alternative)
+- **Pipeline run**: run-2026-05-09-seo1
+
+## DEC-2026-05-09-003: SM-7 closure = first manual workflow_dispatch on merge day (Jericho first-march)
+- **Decision**: For the SEO monitor slice, SM-7 (first scheduled run target ≤ 2026-05-18) closes when the elder runs `gh workflow run seo-monitor.yml` post-merge AND the Issue #58 closure-confirmation comment is posted. The first natural Monday cron tick may follow on 2026-05-11 / 2026-05-18 / 2026-05-25 — corroborating evidence, NOT the gating event.
+- **Why**: Sprint envelope (19.5 Bezalel-hours / 10 working days) cannot fit between 2026-05-09 and the 2026-05-18 cron tick deadline at 2-hour daily blocks. Three calendar exits considered (longer blocks / slip cron / dispatch-day march); dispatch-day march was the cleanest because it makes baseline capture deterministic AND provides the Issue #58 closure attestation in the same action.
+- **Made by**: Orchestrator decision D-6 at Plan self-correction round 1
+- **Reversibility**: Trivial (re-frame SM-7 to first cron tick if the elder prefers the calendar gate)
+- **Pipeline run**: run-2026-05-09-seo1

--- a/.github/workflows/seo-monitor.yml
+++ b/.github/workflows/seo-monitor.yml
@@ -1,0 +1,273 @@
+name: SEO Monitor
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC; first Monday after merge is the first scheduled tick (FR-CI-01)
+  workflow_dispatch:       # Manual trigger; used for the Jericho first-march (deploy-plan §8) and on-demand probes
+
+permissions:
+  contents: read
+  issues: write            # FR-CI-04: post comments on Issue #58
+
+concurrency:
+  group: seo-monitor
+  cancel-in-progress: false
+
+jobs:
+  seo-monitor:
+    name: seo-monitor
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: ./OpenDoorWebsiteApp   # AC-36 - mirrors node-build.yml job-level wd discipline
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      # Step-0: discourse-fidelity guard (D-10). Mirrors node-build.yml's
+      # existing precedent (lines 28-34) - same script, same fail-fast posture.
+      # Failure here aborts the run before any network probe or comment-posting
+      # step executes.
+      - name: Discourse-fidelity check (step-0)
+        working-directory: ${{ github.workspace }}
+        env:
+          BASE_REF: origin/${{ github.base_ref || 'master' }}
+        run: bash scripts/discourse-fidelity-check.sh
+
+      - name: Configure Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'                       # AC-29 - matches node-build.yml line 38
+          cache: 'npm'
+          cache-dependency-path: './OpenDoorWebsiteApp/package-lock.json'
+
+      - name: Install dependencies (npm ci)
+        run: npm ci
+
+      # Per pre-flight Spike 1.1 (PASS-B fired): CRA's react-scripts test
+      # only scans src/** for .{js,jsx,ts,tsx}, so we use the dedicated
+      # npm run test:seo target (jest with the seo-monitor jest.config.cjs).
+      # See OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/ + the
+      # npm run test:seo entry in package.json (eighth script, non-seo:* namespace).
+      - name: Run seo-monitor unit tests
+        env:
+          CI: true
+          NODE_ENV: test
+        run: npm run test:seo
+
+      - name: Run seo:check (capture stdout)
+        id: seo
+        env:
+          CI: true
+        continue-on-error: true
+        run: |
+          set +e
+          npm run seo:check 2>&1 | tee seo-check.out
+          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect MILESTONE_DAY marker
+        id: milestone
+        run: |
+          set -euo pipefail
+          MARKER=$(grep -E '^MILESTONE_DAY=(30|60|90)$' seo-check.out || true)
+          if [ -n "$MARKER" ]; then
+            DAY="${MARKER#MILESTONE_DAY=}"
+            echo "is_milestone=true"  >> "$GITHUB_OUTPUT"
+            echo "milestone_day=$DAY" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_milestone=false" >> "$GITHUB_OUTPUT"
+            echo "milestone_day=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post failure-class comment to Issue #58
+        if: ${{ steps.seo.outputs.exitcode != '0' }}
+        uses: actions/github-script@v7
+        env:
+          UTC_NOW: ${{ github.event.repository.updated_at }}
+          TRIGGER: ${{ github.event_name }}
+          RUNNER_OS: ubuntu-latest
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const stdout = fs.readFileSync('OpenDoorWebsiteApp/seo-check.out', 'utf8');
+
+            // 4KB stdout truncation per FR-CI-04 / cli-ux-spec §11.3.
+            const MAX = 4096;
+            const truncate = (s) => s.length <= MAX ? s : s.slice(0, MAX) + '\n[... truncated to 4096 bytes; see workflow run for full log ...]';
+
+            // Parse SUMMARY lines for the verdict table.
+            const summaryRe = /^SUMMARY (\S+) exit=(\d+) pass=(\d+) fail=(\d+) warn=(\d+) error=(\d+)/gm;
+            const verdicts = [];
+            let m;
+            while ((m = summaryRe.exec(stdout)) !== null) {
+              const sub = m[1];
+              if (sub === 'all') continue;
+              const exit = Number(m[2]);
+              const marker = exit === 0 ? 'PASS' : (exit === 1 ? 'FAIL' : 'ERROR');
+              verdicts.push(`| \`${sub}\` | ${marker} | ${exit} | pass=${m[3]} fail=${m[4]} warn=${m[5]} error=${m[6]} |`);
+            }
+
+            // Carve out failed sub-blocks for the details section.
+            const blocks = stdout.split(/^=== seo-monitor /m).slice(1);
+            const failedBlocks = [];
+            for (const b of blocks) {
+              const blockText = '=== seo-monitor ' + b;
+              const sm = /^SUMMARY \S+ exit=(\d+)/m.exec(blockText);
+              if (sm && Number(sm[1]) !== 0) {
+                failedBlocks.push('```text\n' + truncate(blockText.trim()) + '\n```');
+              }
+            }
+
+            const utc = new Date().toISOString();
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = (context.sha || '').slice(0, 7);
+
+            const body = [
+              `### seo-monitor - FAILURE on ${utc}`,
+              ``,
+              `| Field          | Value                                                              |`,
+              `|----------------|--------------------------------------------------------------------|`,
+              `| UTC time       | \`${utc}\`                                                |`,
+              `| Workflow run   | [${runUrl}](${runUrl})                       |`,
+              `| Trigger        | \`${process.env.TRIGGER}\`                                                      |`,
+              `| Commit         | \`${sha}\`                                             |`,
+              `| Runner OS      | \`ubuntu-latest\`                                                    |`,
+              ``,
+              `#### Subcommand verdicts`,
+              ``,
+              `| Subcommand     | Marker | Exit | Summary                                            |`,
+              `|----------------|--------|------|----------------------------------------------------|`,
+              ...verdicts,
+              ``,
+              `#### Failed subcommand details`,
+              ``,
+              ...failedBlocks,
+              ``,
+              `#### Manual probe`,
+              ``,
+              `Open the Google Rich Results Test for the live page and record the LocalBusiness eligibility verdict in your devlog:`,
+              ``,
+              `- [https://search.google.com/test/rich-results?url=https%3A%2F%2Fopendoorph.org%2F](https://search.google.com/test/rich-results?url=https%3A%2F%2Fopendoorph.org%2F)`,
+              ``,
+              `---`,
+              ``,
+              `Posted by \`seo-monitor.yml\` - disable via \`gh workflow disable seo-monitor.yml\`.`,
+            ].join('\n');
+
+            // Runtime self-check per cli-ux-spec §11.3 / NFR-04 / D-9 surface 2:
+            // grep the rendered body for the country token. Composed from
+            // bytes so this script does not contain the literal.
+            const forbiddenToken = ['p','h','i','l','i','p','p','i','n','e','s'].join('');
+            if (body.toLowerCase().includes(forbiddenToken)) {
+              throw new Error('seo-monitor.yml render-body guard: forbidden country token detected in rendered comment body. Aborting comment-post.');
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: 58,
+              body,
+            });
+
+      - name: Post milestone-class comment to Issue #58
+        if: ${{ steps.milestone.outputs.is_milestone == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          MILESTONE_DAY_NUM: ${{ steps.milestone.outputs.milestone_day }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const stdout = fs.readFileSync('OpenDoorWebsiteApp/seo-check.out', 'utf8');
+
+            const day = process.env.MILESTONE_DAY_NUM;
+            const utc = new Date().toISOString();
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Pull the rank-due block's metadata for baseline/today/days-since.
+            const rankBlockMatch = /=== seo-monitor rank-due ===[\s\S]*?(?=^=== seo-monitor |\Z)/m.exec(stdout);
+            const rankBlock = rankBlockMatch ? rankBlockMatch[0] : '';
+            const todayMatch = /today=(\d{4}-\d{2}-\d{2})/.exec(rankBlock);
+            const baselineMatch = /baseline=(\d{4}-\d{2}-\d{2})/.exec(rankBlock);
+            const daysMatch = /days_since=(\d+)/.exec(rankBlock);
+
+            const baselineLocal = baselineMatch ? baselineMatch[1] : '(unknown)';
+            const todayLocal    = todayMatch    ? todayMatch[1]    : '(unknown)';
+            const daysSince     = daysMatch     ? daysMatch[1]     : day;
+
+            const nextMilestones = day === '30'
+              ? 'Next milestones at days 60 and 90 from your baseline.'
+              : day === '60'
+                ? 'Next milestone at day 90 from your baseline.'
+                : 'rank-due milestones complete after this run; re-baseline only on a new GBP claim.';
+
+            const body = [
+              `### seo-monitor - DAY ${day} milestone reminder`,
+              ``,
+              `| Field                  | Value                                                              |`,
+              `|------------------------|--------------------------------------------------------------------|`,
+              `| UTC time               | \`${utc}\`                                                |`,
+              `| Workflow run           | [${runUrl}](${runUrl})                       |`,
+              `| Baseline (local)       | \`${baselineLocal}\` (America/Chicago)                        |`,
+              `| Today (local)          | \`${todayLocal}\` (America/Chicago)                                |`,
+              `| Days since baseline    | \`${daysSince}\`                                                   |`,
+              ``,
+              `#### Action checklist (runbook 5.4)`,
+              ``,
+              `Run each query in a clean browser session (no Google account signed in) from a Pleasant Hill area network if possible. Record the rank position for \`opendoorph.org\` in your devlog.`,
+              ``,
+              `- [ ] \`church pleasant hill mo\``,
+              `- [ ] \`full gospel church pleasant hill\``,
+              `- [ ] \`pentecostal church pleasant hill mo\``,
+              `- [ ] \`open door full gospel church\``,
+              ``,
+              `#### Manual probe`,
+              ``,
+              `While you have a browser open, also re-run the Google Rich Results Test for the live page:`,
+              ``,
+              `- [https://search.google.com/test/rich-results?url=https%3A%2F%2Fopendoorph.org%2F](https://search.google.com/test/rich-results?url=https%3A%2F%2Fopendoorph.org%2F)`,
+              ``,
+              `---`,
+              ``,
+              `Posted by \`seo-monitor.yml\` - disable via \`gh workflow disable seo-monitor.yml\`. ${nextMilestones}`,
+            ].join('\n');
+
+            // Runtime self-check per cli-ux-spec §11.3 / NFR-04 / D-9 surface 2.
+            const forbiddenToken = ['p','h','i','l','i','p','p','i','n','e','s'].join('');
+            if (body.toLowerCase().includes(forbiddenToken)) {
+              throw new Error('seo-monitor.yml render-body guard: forbidden country token detected in rendered comment body. Aborting comment-post.');
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: 58,
+              body,
+            });
+
+      - name: Upload seo-check stdout (audit trail)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seo-check-stdout
+          path: ./OpenDoorWebsiteApp/seo-check.out
+          retention-days: 30
+
+      - name: Upload Lighthouse HTML report (when present)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: ./OpenDoorWebsiteApp/scripts/seo-monitor/.cache/*.html
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Re-raise non-zero exit (so run history shows red)
+        if: ${{ steps.seo.outputs.exitcode != '0' }}
+        run: |
+          echo "seo:check exited ${{ steps.seo.outputs.exitcode }}; re-raising so the run is marked failed."
+          exit ${{ steps.seo.outputs.exitcode }}

--- a/OpenDoorWebsiteApp/.gitignore
+++ b/OpenDoorWebsiteApp/.gitignore
@@ -33,3 +33,8 @@ yarn-error.log*
 test-results/
 playwright-report/
 playwright/.cache/
+
+# seo-monitor (Issue #58 slice C) — runtime caches; never committed
+scripts/seo-monitor/.cache/
+.lighthouseci/
+seo-check.out

--- a/OpenDoorWebsiteApp/README.md
+++ b/OpenDoorWebsiteApp/README.md
@@ -42,6 +42,12 @@ npm run build
 
 **Note**: Build scripts use `cross-env` to set environment variables directly, ensuring cross-platform compatibility.
 
+## Scripts & utilities
+
+Operational utilities live under `OpenDoorWebsiteApp/scripts/`. Each utility carries its own README with subcommand reference, exit-code semantics, and troubleshooting guidance.
+
+- [`scripts/seo-monitor/`](scripts/seo-monitor/README.md) — SEO monitoring + post-merge UAT automation utility (`npm run seo:check`). Wraps four-domain canonical posture, JSON-LD schema invariants, Lighthouse SEO/A11y/Perf, Rich Results URL, and 30/60/90-day rank-tracking milestone signaller. Scheduled weekly via `.github/workflows/seo-monitor.yml`.
+
 ## Local Development
 
 1. Start the development server:

--- a/OpenDoorWebsiteApp/package-lock.json
+++ b/OpenDoorWebsiteApp/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.2",
+        "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.59.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/user-event": "^14.6.1",
@@ -2329,6 +2330,62 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2842,6 +2899,172 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
+    "node_modules/@lhci/cli": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.15.1.tgz",
+      "integrity": "sha512-yhC0oXnXqGHYy1xl4D8YqaydMZ/khFAnXGY/o2m/J3PqPa/D0nj3V6TLoH02oVMFeEF2AQim7UbmdXMiXx2tOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lhci/utils": "0.15.1",
+        "chrome-launcher": "^0.13.4",
+        "compression": "^1.7.4",
+        "debug": "^4.3.1",
+        "express": "^4.17.1",
+        "inquirer": "^6.3.1",
+        "isomorphic-fetch": "^3.0.0",
+        "lighthouse": "12.6.1",
+        "lighthouse-logger": "1.2.0",
+        "open": "^7.1.0",
+        "proxy-agent": "^6.4.0",
+        "tmp": "^0.1.0",
+        "uuid": "^8.3.1",
+        "yargs": "^15.4.1",
+        "yargs-parser": "^13.1.2"
+      },
+      "bin": {
+        "lhci": "src/cli.js"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@lhci/cli/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/yargs/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@lhci/utils": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@lhci/utils/-/utils-0.15.1.tgz",
+      "integrity": "sha512-WclJnUQJeOMY271JSuaOjCv/aA0pgvuHZS29NFNdIeI14id8eiFsjith85EGKYhljgoQhJ2SiW4PsVfFiakNNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "isomorphic-fetch": "^3.0.0",
+        "js-yaml": "^3.13.1",
+        "lighthouse": "12.6.1",
+        "tree-kill": "^1.2.1"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -2900,6 +3123,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paulirish/trace_engine": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.53.tgz",
+      "integrity": "sha512-PUl/vlfo08Oj804VI5nDPeSk9vyslnBlVzDDwFt8SUVxY8+KdGMkra/vrXjEEHe8gb7+RqVTfOIlGw0nyrEelA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "legacy-javascript": "latest",
+        "third-party-web": "latest"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2972,6 +3206,72 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.1.tgz",
+      "integrity": "sha512-zmS4RTK9fbrc++WlAJhxYbfz3IjDeOmkK/CwwbLmk7ydfS9e2CiEeRJHEPvjDVElO/bwXbidwGA37Bsm6LzCnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@remix-run/router": {
@@ -3066,6 +3366,91 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw=="
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.4.tgz",
+      "integrity": "sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.4.tgz",
+      "integrity": "sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
+      "integrity": "sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.120.4.tgz",
+      "integrity": "sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/integrations": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.4.tgz",
+      "integrity": "sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.4.tgz",
+      "integrity": "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -3395,6 +3780,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -3961,6 +4353,17 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
@@ -4516,6 +4919,16 @@
         "string-width": "^4.1.0"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -4822,6 +5235,19 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
@@ -5164,6 +5590,103 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -5171,6 +5694,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/batch": {
@@ -5476,6 +6009,16 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5671,6 +6214,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-types": {
       "version": "11.2.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
@@ -5710,12 +6260,51 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chrome-launcher": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
+      "integrity": "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^1.0.5",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^0.5.3",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
       }
     },
     "node_modules/ci-info": {
@@ -5767,6 +6356,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/clipboardy": {
       "version": "3.0.0",
@@ -5990,6 +6599,24 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -6130,6 +6757,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.5.tgz",
+      "integrity": "sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/css-blank-pseudo": {
       "version": "3.0.3",
@@ -6492,6 +7126,16 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -6554,9 +7198,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -6567,6 +7212,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -6652,6 +7307,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -6726,6 +7396,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1467305",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
+      "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -6871,6 +7548,29 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-prop/node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
@@ -6964,6 +7664,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.19.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
@@ -6975,6 +7685,20 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -7819,6 +8543,16 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7943,10 +8677,95 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -8024,6 +8843,39 @@
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -8555,6 +9407,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -8979,6 +9846,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-link-header": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -9099,6 +9976,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "9.0.21",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
@@ -9185,6 +10076,189 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inquirer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -9196,6 +10270,29 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -9694,6 +10791,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -10675,6 +11783,23 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-library-detector": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10898,6 +12023,13 @@
         "shell-quote": "^1.8.1"
       }
     },
+    "node_modules/legacy-javascript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+      "integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -10916,6 +12048,180 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lighthouse": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.6.1.tgz",
+      "integrity": "sha512-85WDkjcXAVdlFem9Y6SSxqoKiz/89UsDZhLpeLJIsJ4LlHxw047XTZhlFJmjYCB7K5S1erSBAf5cYLcfyNbH3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@paulirish/trace_engine": "0.0.53",
+        "@sentry/node": "^7.0.0",
+        "axe-core": "^4.10.3",
+        "chrome-launcher": "^1.2.0",
+        "configstore": "^5.0.1",
+        "csp_evaluator": "1.1.5",
+        "devtools-protocol": "0.0.1467305",
+        "enquirer": "^2.3.6",
+        "http-link-header": "^1.1.1",
+        "intl-messageformat": "^10.5.3",
+        "jpeg-js": "^0.4.4",
+        "js-library-detector": "^6.7.0",
+        "lighthouse-logger": "^2.0.1",
+        "lighthouse-stack-packs": "1.12.2",
+        "lodash-es": "^4.17.21",
+        "lookup-closest-locale": "6.2.0",
+        "metaviewport-parser": "0.3.0",
+        "open": "^8.4.0",
+        "parse-cache-control": "1.0.1",
+        "puppeteer-core": "^24.10.0",
+        "robots-parser": "^3.0.1",
+        "semver": "^5.3.0",
+        "speedline-core": "^1.4.3",
+        "third-party-web": "^0.26.6",
+        "tldts-icann": "^6.1.16",
+        "ws": "^7.0.0",
+        "yargs": "^17.3.1",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+        "lighthouse": "cli/index.js",
+        "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+      },
+      "engines": {
+        "node": ">=18.20"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+      "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lighthouse-stack-packs": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.2.tgz",
+      "integrity": "sha512-Ug8feS/A+92TMTCK6yHYLwaFMuelK/hAKRMdldYkMNwv+d9PtWxjXEg6rwKtsUXTADajhdrhXyuNCJ5/sfmPFw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lighthouse/node_modules/chrome-launcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/lighthouse/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lighthouse/node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/lighthouse/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lighthouse/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lilconfig": {
@@ -10957,6 +12263,16 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -10972,6 +12288,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -10998,6 +12321,13 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "node_modules/lookup-closest-locale": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -11072,6 +12402,13 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -11124,6 +12461,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/metaviewport-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
+      "integrity": "sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -11243,6 +12587,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -11270,6 +12621,13 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -11321,6 +12679,16 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -11328,6 +12696,52 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -11617,6 +13031,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -11678,6 +13102,78 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -11702,6 +13198,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -11805,6 +13307,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -13253,6 +14762,16 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -13308,6 +14827,81 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -13319,12 +14913,71 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.0.tgz",
+      "integrity": "sha512-cCRNXsUlhyPoKDz6+TiSpfZpRS3mD6Y1YFKhkdr6ik6TMfuJb7fAtXq9ThUFc4sphxObDk3BuAvdxc1Y6YOnqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.1",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/q": {
@@ -13922,6 +15575,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -14034,6 +15694,43 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -14064,6 +15761,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/rollup": {
@@ -14109,6 +15816,16 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -14130,6 +15847,26 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -14339,9 +16076,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -14624,6 +16362,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -14788,6 +16533,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -14796,6 +16552,46 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/source-list-map": {
@@ -14890,6 +16686,21 @@
         "wbuf": "^1.7.3"
       }
     },
+    "node_modules/speedline-core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -14952,6 +16763,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -15549,6 +17372,59 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -15669,6 +17545,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -15693,15 +17594,73 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/third-party-web": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.26.7.tgz",
+      "integrity": "sha512-buUzX4sXC4efFX6xg2bw6/eZsCUh8qQwSavC4D9HpONMFlRbcHhD8Je5qwYdCpViR6q0qla2wPP+t91a2vgolg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/throat": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
       "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ=="
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts-icann": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.86.tgz",
+      "integrity": "sha512-NFxmRT2lAEMcCOBgeZ0NuM0zsK/xgmNajnY6n4S1mwAKocft2s2ise1O3nQxrH3c+uY6hgHUV9GGNVp7tUE4Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rimraf": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tmp/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -15758,6 +17717,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/tryer": {
@@ -15935,6 +17904,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -16237,6 +18213,13 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -16594,6 +18577,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
@@ -17076,6 +19066,16 @@
         }
       }
     },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -17133,6 +19133,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -17142,6 +19153,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/OpenDoorWebsiteApp/package.json
+++ b/OpenDoorWebsiteApp/package.json
@@ -39,7 +39,15 @@
     "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
     "lint:fix": "eslint src/**/*.{js,jsx,ts,tsx} --fix",
     "type-check": "tsc --noEmit",
-    "type-check:watch": "tsc --noEmit --watch"
+    "type-check:watch": "tsc --noEmit --watch",
+    "seo:check": "node scripts/seo-monitor/seo-monitor.mjs all",
+    "seo:canonical": "node scripts/seo-monitor/seo-monitor.mjs canonical",
+    "seo:schema": "node scripts/seo-monitor/seo-monitor.mjs schema",
+    "seo:lighthouse": "node scripts/seo-monitor/seo-monitor.mjs lighthouse",
+    "seo:rich-results": "node scripts/seo-monitor/seo-monitor.mjs rich-results",
+    "seo:rank-due": "node scripts/seo-monitor/seo-monitor.mjs rank-due",
+    "seo:all": "node scripts/seo-monitor/seo-monitor.mjs all",
+    "test:seo": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config scripts/seo-monitor/jest.config.cjs"
   },
   "eslintConfig": {
     "extends": [
@@ -61,6 +69,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.2",
+    "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.59.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/user-event": "^14.6.1",

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/README.md
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/README.md
@@ -1,0 +1,246 @@
+# seo-monitor
+
+> "He read from the book, and gave the sense, so that the people understood the reading." This document is the scribe's faithful account of the `seo-monitor` utility as it stands on disk in run-2026-05-09-seo1: six subcommands plus an umbrella, one weekly workflow, three exit codes, and one stable last-line marker. Every sentence below has been verified against the source, the workflow YAML, the package.json, and the cli-ux-spec — so that the elder may know the certainty of the keystrokes he has been taught, and PH be read as Pleasant Hill in every line.
+
+## Overview
+
+`seo-monitor` is a plain Node.js (ESM) CLI utility that automates SEO and post-merge UAT checks for the OpenDoor Pleasant Hill website. It probes the four canonical domains, asserts JSON-LD schema invariants against the served `.org` HTML, captures Lighthouse SEO/A11y/Performance scores against a stored baseline, prints the Google Rich Results Test URL pre-filled for the live page, and signals 30/60/90-day rank-tracking milestones from a configurable baseline date. It is invoked locally by the elder (or any developer) from `OpenDoorWebsiteApp/`, and on a weekly schedule (plus on demand) by `.github/workflows/seo-monitor.yml`. The utility does not block PR merges, does not edit `node-build.yml`, never accepts auth tokens, and never writes state outside its own `.cache/` directory.
+
+It runs in three contexts:
+
+- **Locally** — the elder runs `npm run seo:check` from `OpenDoorWebsiteApp/` whenever a check is desired.
+- **Weekly cron** — `.github/workflows/seo-monitor.yml` fires every Monday at `06:00` UTC (`cron: '0 6 * * 1'`).
+- **On-demand CI** — `gh workflow run seo-monitor.yml` (or the GitHub UI's "Run workflow" button) triggers the same job via `workflow_dispatch`.
+
+There are no `push` or `pull_request` triggers. The workflow is observability and reminder; it is never a deploy gate.
+
+## Subcommands
+
+The reader who learns this table has learned the surface. Each subcommand is independently invokable. The umbrella `all` runs the first five in sequence and composes its exit code from the first four (rank-due always returns 0 by contract, so it can never dilute the failure signal). Stable strings are mirrored verbatim from `cli-ux-spec.md` §10.
+
+| Subcommand     | What it checks                                                        | Exit-code semantics                                                   | Typical stdout summary line                                                  |
+|----------------|------------------------------------------------------------------------|------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| `canonical`    | Four-domain redirect chain (`.info`, `.net`, `.com`, `.org`) ends at `https://opendoorph.org/`, accepting either 301/302 redirect or 200 + `<link rel=canonical>` posture | `0` all match; `1` per-domain MISMATCH; `2` TRANSPORT_ERROR (DNS / TLS / timeout) | `SUMMARY canonical exit=0 pass=4 fail=0 warn=0 error=0`                      |
+| `schema`       | Live `.org` HTML has exactly one `application/ld+json` block; `@context`, `@type`, `url`, `<link rel=canonical>`, `sameAs.length===1`, NAP byte-equality (when `<address>` present) | `0` all assertions pass; `1` any FR-SCHEMA assertion fails; `2` TRANSPORT_ERROR | `SUMMARY schema exit=0 pass=6 fail=0 warn=1 error=0`                          |
+| `lighthouse`   | Median of N (default 3) `lhci collect` runs on `/`; A11y hard floor of 90 | `0` A11y >= 90; `1` A11y < 90; `2` `LHCI_BINARY_MISSING` or Chromium-not-discovered or transport | `SUMMARY lighthouse exit=0 pass=1 fail=0 warn=0 error=0 a11y=96 seo=92 perf=99` |
+| `rich-results` | Prints the pre-filled Google Rich Results Test URL for `https://opendoorph.org/`; **zero network calls** | Always `0` (FR-RR-02)                                                  | `SUMMARY rich-results exit=0 pass=0 fail=0 warn=0 error=0`                    |
+| `rank-due`     | Days since `baseline_date` (in `America/Chicago` civil time); banner + checklist on day 30/60/90 | Always `0` (FR-RANK-07) — silent on non-milestone days; informational on every state | `SUMMARY rank-due exit=0 pass=0 fail=0 warn=0 error=0 milestone_day=none`     |
+| `all`          | Runs canonical -> schema -> lighthouse -> rich-results -> rank-due in sequence | Bitwise-OR of the first four exits ONLY (rank-due excluded by FR-CLI-03); legal values `{0, 1, 2, 3}` | `SUMMARY all exit=0 pass=11 fail=0 warn=2 error=0 milestone_day=none`         |
+
+Every subcommand block begins with `=== seo-monitor <subcmd> ===`, ends with `SUMMARY <subcmd> exit=<N> ...`, and carries a trailing `EXIT: <N>` line for human skimming. For `rank-due` (and any `all` invocation that includes it), the **very last line of stdout** is the milestone marker `MILESTONE_DAY=` followed by `30`, `60`, `90`, or `none`. The workflow detects the marker via grep, never via exit code.
+
+## Local usage
+
+The elder's everyday surface is `npm run seo:check`. Each subcommand also has a per-name script. Run from inside `OpenDoorWebsiteApp/`.
+
+First-time setup plus the umbrella check, in a single copy-pasteable line per cli-ux-spec.md §7's "Quick start - Local" promise:
+
+```bash
+cd OpenDoorWebsiteApp && npm install && npm run seo:check
+```
+
+Subsequent runs of the umbrella (after `npm install` has been run once):
+
+```bash
+cd OpenDoorWebsiteApp
+npm run seo:check
+```
+
+Run an individual subcommand:
+
+```bash
+cd OpenDoorWebsiteApp
+npm run seo:canonical
+npm run seo:schema
+npm run seo:lighthouse
+npm run seo:rich-results
+npm run seo:rank-due
+npm run seo:all          # alias of seo:check
+```
+
+Run the unit + integration tests for the utility:
+
+```bash
+cd OpenDoorWebsiteApp
+npm run test:seo
+```
+
+A note on the test invocation, scribed at sentence-level precision: the project's primary `npm test` script invokes `react-scripts test`, which restricts its `testMatch` to `src/**` with `.{js,jsx,ts,tsx}` extensions only. The `seo-monitor` tests live at `OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/**/*.test.mjs` — outside `src/` and using the `.mjs` extension — so they are invisible to `npm test`. The dedicated `npm run test:seo` script (the eighth and final entry in `package.json`'s `scripts` block) runs Jest with `--experimental-vm-modules` against the standalone `scripts/seo-monitor/jest.config.cjs`. This is the PASS-B fallback path documented in story S-09 AC-6 and Bezalel's pre-flight Spike 1.1; the `ExperimentalWarning` line emitted to stderr does not affect the exit code.
+
+You may also invoke the entry point directly without npm:
+
+```bash
+node OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.mjs --help
+node OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.mjs canonical
+```
+
+The dispatcher resolves its anchor against its own `__dirname`, so invocation from project root and from `OpenDoorWebsiteApp/` produce identical behavior (FR-CLI-05 / AC-23).
+
+## Fedora 43 Chromium for `npm run seo:lighthouse`
+
+Lighthouse is launched by `@lhci/cli`, which does not bundle a browser binary. On Fedora 43 the elder's box ships no `chromium-browser`, no `chromium`, and no `google-chrome` in `PATH` by default; the lhci runtime therefore reports `The CHROME_PATH environment variable must be set to a Chrome/Chromium executable no older than Chrome stable.` until a binary is named.
+
+Bezalel's S-04 spike resolved this on the elder's box via PASS-B: Playwright's bundled Chromium (placed there by an earlier `npx playwright install` for the slice-A E2E suite) is a stable Chromium and works as the `CHROME_PATH` target. The verbatim invocation that succeeded:
+
+```bash
+CHROME_PATH=/var/home/meconnelly/.cache/ms-playwright/chromium-1217/chrome-linux64/chrome \
+    npm run seo:lighthouse
+```
+
+Captured Lighthouse scores from that run: SEO=92, A11y=96, Perf=99, Best-Practices=96. A11y comfortably above the NFR-02 hard floor of 90.
+
+For Fedora users **without** a Playwright cache, install Chromium via the system package manager and point `CHROME_PATH` at the result:
+
+```bash
+# Fedora 43 (the elder's environment):
+sudo dnf install chromium
+export CHROME_PATH=/usr/bin/chromium-browser
+
+# Debian / Ubuntu equivalent:
+sudo apt-get install chromium
+export CHROME_PATH=/usr/bin/chromium-browser
+
+npm run seo:lighthouse
+```
+
+If Chromium is not discovered, the `lighthouse` subcommand surfaces the gap explicitly: it emits an `ERROR lighthouse: chromium binary not discovered. Set CHROME_PATH=/usr/bin/chromium-browser (or equivalent) and re-run.` line and exits `2` (FR-LH-05 / AC-37 path b). The diagnostic names the same env-var path documented above, so the README and the source remain in lockstep.
+
+## GitHub Actions workflow
+
+The workflow file is `.github/workflows/seo-monitor.yml` (NEW in this slice; zero edits to `node-build.yml` per BUG-053-01 / NFR-05). Its triggers are exactly:
+
+- `schedule:` weekly cron `0 6 * * 1` (Mondays at 06:00 UTC, per FR-CI-01)
+- `workflow_dispatch:` for manual runs from the GitHub UI or `gh workflow run seo-monitor.yml`
+
+Workflow-level permissions are scoped to `contents: read` and `issues: write`. Concurrency group `seo-monitor` is set with `cancel-in-progress: false`, so a running scheduled job is never killed by a manual dispatch.
+
+The job runs on `ubuntu-latest`, with `defaults.run.working-directory: ./OpenDoorWebsiteApp` (mirroring `node-build.yml`'s working-directory discipline). The step sequence is:
+
+1. `actions/checkout@v4` (`fetch-depth: 1`).
+2. `bash scripts/discourse-fidelity-check.sh` — the discourse-fidelity guard (D-10), invoked from `${{ github.workspace }}` to override the job-level wd; mirrors the precedent in `node-build.yml` lines 28-34.
+3. `actions/setup-node@v4` with `node-version: '20'` (AC-29; matches `node-build.yml`'s Node version), npm cache keyed off `OpenDoorWebsiteApp/package-lock.json`.
+4. `npm ci`.
+5. `npm run test:seo` — the seo-monitor Jest suite (PASS-B fallback per Spike 1.1).
+6. `npm run seo:check 2>&1 | tee seo-check.out` with `set +e` and `continue-on-error: true`. `PIPESTATUS[0]` is captured to `$GITHUB_OUTPUT` so later steps see the real exit code from `seo:check`, not from `tee`.
+7. `Detect MILESTONE_DAY marker` — a single `grep -E '^MILESTONE_DAY=(30|60|90)$' seo-check.out`, matching only the three milestone forms per D-3.
+8. `Post failure-class comment to Issue #58` — `actions/github-script@v7`, conditional on the captured exit code being non-zero. Renders the cli-ux-spec §11.1 failure template (subcommand verdict table; failed-block details fenced; baseline diff when lighthouse ran; manual-probe CTA; footer). Truncates each failed-block stdout to 4096 bytes with the in-band `[... truncated to 4096 bytes; see workflow run for full log ...]` marker. Includes a runtime self-check (per cli-ux-spec §11.3 / D-9 surface 2) that composes the country token from harmless bytes and throws **before** posting if it ever appears in the rendered body.
+9. `Post milestone-class comment to Issue #58` — independent of step 8; conditional on the milestone step's `is_milestone == 'true'`. Renders the cli-ux-spec §11.2 milestone template (run metadata; the four runbook 5.4 queries as a Markdown checklist; manual-probe CTA; footer with the next-milestone narrative). Same forbidden-token guard.
+10. `Upload seo-check stdout` artifact (30-day retention).
+11. `Upload Lighthouse HTML report` artifact when present (`if-no-files-found: ignore`; 30-day retention).
+12. `Re-raise non-zero exit` — surfaces the `seo:check` exit code at the run level so the GitHub Actions UI shows red.
+
+A milestone-day tick that coincides with a regression in `canonical`/`schema`/`lighthouse` produces **two** comments on Issue #58 (one failure-class, one milestone-class) — by design, per cli-ux-spec §6.3, so that neither signal buries the other.
+
+## Configuration (`seo-monitor.config.json`)
+
+The config file lives at `OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.config.json` and is committed with sentinel `null` values. The elder edits it post-merge as the operational dates land. Three keys are recognized:
+
+```json
+{
+    "baseline_date": null,
+    "lighthouse_baseline": {
+        "seo": null,
+        "accessibility": null,
+        "performance": null,
+        "best_practices": null
+    },
+    "canonical_domain": "opendoorph.org"
+}
+```
+
+| Key                              | Purpose                                                                                                  | When the elder sets it                                                                          |
+|----------------------------------|----------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| `baseline_date`                  | ISO-8601 date string (`YYYY-MM-DD`) — the elder's GBP verification date, the day the rank-tracking clock starts. Read by `rank-due` (FR-RANK-01); overridable per-invocation by `--baseline-date YYYY-MM-DD`. | After completing runbook Phase 5.1-5.3 (GBP verification). Until then the field stays `null` and `rank-due` emits `INFO rank-due: not yet armed; populate config.json from runbook 5.1` and exits 0. |
+| `lighthouse_baseline`            | The first-run captured median scores (SEO, A11y, Performance, Best-Practices). Subsequent `lighthouse` runs compare against these and emit `WARN lighthouse: SEO regression baseline=N current=M` when current is below baseline. **Only A11y crashes the floor** (FR-LH-03); SEO/Perf regressions are informational per FR-LH-04. | Captured automatically on the first successful `npm run seo:lighthouse` run. The elder may force a re-baseline by running with `--baseline-write`. |
+| `canonical_domain`               | The expected redirect target for the four-domain canonical check. Default `opendoorph.org` per DEC-2026-05-03-001. | Should not normally be edited; changing it would break the canonical contract. |
+
+State written by the utility (Lighthouse HTML reports, lhci `.cache/`, `seo-check.out`) is git-ignored. Only the config file itself is committed.
+
+## The MILESTONE_DAY marker
+
+The contract per locked decision D-3:
+
+- The `rank-due` subcommand emits a final stdout line `MILESTONE_DAY=` followed by exactly one of `30`, `60`, `90`, or `none`. The emitted form is pinned to the regex below, byte-for-byte (matches the source-code comment in `seo-monitor.mjs` and the cli-ux-spec.md §10 glossary entry):
+
+  ```text
+  ^MILESTONE_DAY=(30|60|90|none)$
+  ```
+
+- The workflow's `Detect MILESTONE_DAY marker` step greps with the narrower form `^MILESTONE_DAY=(30|60|90)$` — **matching only the three milestone forms**. The `=none` form is a stable string for log-completeness but is NOT a milestone trigger, and never produces a comment.
+- The marker is decoupled from the exit code. `rank-due` always exits `0` (FR-RANK-07). The workflow's milestone-comment step is gated on the grep, not the exit code. This closes Solomon's adversarial finding #2.
+
+Honest scope note: the marker is a **reminder**, not a measurement. The slice does not perform the rank lookup itself. When a `MILESTONE_DAY=30|60|90` comment lands on Issue #58, the elder runs the four runbook 5.4 queries by hand (in a clean browser session, ideally from a Pleasant Hill area network) and records the rank position for `opendoorph.org` in the devlog. Slice C may automate the lookup later; this slice only ensures the elder is told *today is a milestone day* on the day it is, instead of relying on Google Calendar alone.
+
+## First-run / Jericho first-march
+
+The day the slice merges (target 2026-05-11), the elder closes three carryover items in a single coordinated act, per locked decision D-6:
+
+1. Trigger the workflow manually, either via the GitHub UI's "Run workflow" button on the SEO Monitor workflow page, or from a shell with the `gh` CLI:
+
+   ```bash
+   gh workflow run seo-monitor.yml -R OpenDoorPH/OpenDoorPH-website
+   ```
+
+2. The workflow_dispatch run captures the first Lighthouse baseline at `OpenDoorWebsiteApp/scripts/seo-monitor/.cache/lighthouse-baseline.json` (closes the slice-A PRD §2.4 spike target due 2026-05-11 — captured, not retroactive).
+
+3. The same run executes `seo-monitor canonical` and `seo-monitor schema` against the four domains (closes the two overdue slice-A release-notes USER actions: the production curl post-merge verification at 4 days overdue, and the four-domain `.info`/`.net`/`.com` posture check). The live demo URL post-merge verification remains the elder's separate responsibility via the existing `demo-deploy` job in `node-build.yml` (out of scope for `seo-monitor` per PRD §3.2 #11).
+
+4. SM-7 (the success metric "first scheduled run lands before 2026-05-18") closes the same day if the workflow_dispatch run is green; the first scheduled tick that follows (Monday 2026-05-18 06:00 UTC) is then a confirmation, not a first probe.
+
+The workflow's first run also posts no failure comment (because all four S1-S4 subcommands are expected to pass) and no milestone comment (because the GBP verification date will not yet be 30/60/90 days in the past). This is the silent-success state the cron is designed to produce in steady operation.
+
+## What this utility does NOT do
+
+The scribe is patient with what is, and equally patient with what is not. Every sentence in this section has been verified against PRD §3.2 and §10.
+
+- **Does NOT claim or manage the Google Business Profile (Slice B; off-pipeline).** The utility never calls the GBP API, never claims listings, never interacts with Bing Places, Apple Maps Connect, or denominational directories. The elder runs the GBP claim workflow per `.delivery/artifacts/58b-ops-checklist/runbook.md`.
+- **Does NOT perform rank lookups (manual; the elder runs them on milestone days).** The `rank-due` subcommand signals; the elder queries. There is no SERP scraper, no paid rank-tracker integration, no result-parsing heuristic.
+- **Does NOT call the Google Search Console API** (or PageSpeed Insights API auth path, or any other auth-bearing Google API). Lighthouse is run locally via `@lhci/cli` against the public URL; no auth.
+- **Does NOT use auth tokens.** Zero `*KEY` / `*TOKEN` / `*SECRET` / `GSC_` / `GOOGLE_API` env-var references in source. The workflow uses only the default `GITHUB_TOKEN` (scoped to `issues: write`) for posting comments.
+- **Does NOT block PR merge or deploy.** The workflow has no `push` or `pull_request` triggers, no `needs:` references to `node-build.yml` jobs, and no branch-protection mutations.
+- **Does NOT edit `node-build.yml`.** This slice's PR contains exactly one new workflow file (`.github/workflows/seo-monitor.yml`) and zero changes to `node-build.yml` (BUG-053-01 / NFR-05; Bezalel verified `git diff master -- .github/workflows/node-build.yml` returns empty).
+- **Does NOT scan multiple pages with Lighthouse.** Scope is `/` only (matching slice-A's NFR-01/02/03 measurement scope).
+- **Does NOT add new runtime `dependencies`.** Exactly one new devDependency was added in this slice: `@lhci/cli` (caret-pinned in `package.json`). Zero new entries under `dependencies`.
+
+## Troubleshooting
+
+The five-plus modes most likely to fire on the elder's box, drawn from cli-ux-spec.md §5 and the two implementation deviations Bezalel logged in his S-02 and S-03 sections.
+
+### `FAIL canonical: opendoorph.<sister> -> ... expected=https://opendoorph.org/`
+
+A sister domain returned a final URL other than `https://opendoorph.org/` (e.g., a registrar parking page). The implementation accepts two postures (FR-CANON-01): a 301/302 chain ending at `.org` (posture a), OR a `200` response whose body contains a `<link rel=canonical>` href equal to `https://opendoorph.org/` (posture b — added in S-02 after Bezalel's Step-7 stdout verification revealed all three sister domains serve identical 200 HTML out of the same S3+CloudFront origin set, with no edge redirect). If a parking page is rendered instead, the canonical link will be missing or wrong. Restore the registrar redirect record or re-deploy the React build to the affected origin.
+
+### `WARN schema: NAP byte-equal skipped: no <address> element in served HTML`
+
+The schema subcommand's NAP byte-equality check requires a rendered `<address>` element to compare against the JSON-LD `streetAddress + postalCode + telephone` tuple. In production the served HTML is a React SPA skeleton — there is no `<address>` element until React hydrates client-side. Per the spirit of FR-SCHEMA-06 and the slice-A `napByteMatch.test.ts` precedent (which runs against the JSDOM-rendered build), this branch emits a WARN advisory and exits `0`. The slice-A build-time test continues to cover the JSDOM byte-match invariant. This is **not** a failure mode — it is the documented S-03 deviation. If you see this WARN line, the check is doing exactly what was specified.
+
+### `ERROR lighthouse: chromium binary not discovered. Set CHROME_PATH=/usr/bin/chromium-browser (or equivalent) and re-run.`
+
+`@lhci/cli` could not find a Chromium executable. Follow the "Fedora 43 Chromium" section above — either point `CHROME_PATH` at a Playwright cache binary or `sudo dnf install chromium` and use `/usr/bin/chromium-browser`. On `ubuntu-latest` (the CI runner) Chromium is provisioned by default and this error should not appear.
+
+### `ERROR lighthouse: LHCI_BINARY_MISSING - run 'cd OpenDoorWebsiteApp && npm install'`
+
+The `@lhci/cli` devDependency is not installed. Run `cd OpenDoorWebsiteApp && npm install` (or `npm ci` on a clean clone). The diagnostic line names the exact remediation command; no further investigation needed.
+
+### `ERROR canonical: opendoorph.<domain> unreachable cause=ENOTFOUND timeout_s=10`
+
+A transport-class failure (DNS NXDOMAIN, TLS handshake error, connection refused, or timeout) — distinct from an assertion failure. Exit code is `2`, not `1`. From the elder's shell, run `dig opendoorph.<domain> +short` to confirm whether DNS is broken at the registrar; if `dig` returns no answer, the registrar nameservers are misconfigured; if `dig` works but the subcommand still fails, re-run with `--timeout-seconds 30`. Same diagnostic shape applies to `schema` (`ECONNREFUSED` -> CloudFront / S3 origin issue; consult SV-001's most recent run in `node-build.yml`) and `lighthouse`.
+
+### `ERROR usage: unknown subcommand "<typo>". did you mean "<suggestion>"?`
+
+A typo or unrecognized subcommand. The dispatcher computes a Levenshtein-style suggestion and prints it; exit code is `2` (USAGE_ERROR class per FR-CLI-02). The HELP screen follows automatically — the help is always one keystroke away.
+
+### `WARN lighthouse: runs=N (PRD pins 3)`
+
+You ran `--runs=N` with `N != 3`. The PRD pins 3-run median for stable scoring. Lower values are accepted for spike work but the WARN is emitted so it is recorded in the devlog; exit code is unchanged.
+
+## References
+
+- PRD: [`.delivery/artifacts/02-refine/po/prd.md`](../../../.delivery/artifacts/02-refine/po/prd.md) (FR-CANON, FR-SCHEMA, FR-LH, FR-RR, FR-RANK, FR-CLI, FR-CI, FR-PKG; NFR-01..NFR-09; AC-1..AC-38)
+- CLI / UX spec: [`.delivery/artifacts/03-design/ux/cli-ux-spec.md`](../../../.delivery/artifacts/03-design/ux/cli-ux-spec.md) (subcommand grammar, exit codes, output format, failure-mode catalogue, comment templates)
+- Stories (S-01..S-10): [`.delivery/artifacts/05-plan/po/stories.md`](../../../.delivery/artifacts/05-plan/po/stories.md)
+- Slice-A release notes (the two overdue items this slice retires): [`.delivery/artifacts/_inputs/slice-a/release-notes.md`](../../../.delivery/artifacts/_inputs/slice-a/release-notes.md) (verify path; consult `_inputs/` directly if the link drifts)
+- Slice-A PRD §2.4 (the upcoming Lighthouse-baseline spike target this slice captures)
+- Issue umbrella: [Issue #58](https://github.com/OpenDoorPH/OpenDoorPH-website/issues/58)
+- Locked decisions: [`.delivery/state.md`](../../../.delivery/state.md) — D-3 (MILESTONE_DAY regex split), D-5 (extractNAP `.cjs` shim), D-6 (Jericho first-march), D-9 (forbidden-string surfaces), D-10 (workflow step-0 discourse-fidelity guard)
+- Hot lessons honored: BUG-053-01 (NEW workflow file; zero edits to `node-build.yml`), NFR-04 (PH = Pleasant Hill, never the Southeast-Asian island nation), `feedback_test_before_push` (run tests locally before push), `feedback_source_prd_is_spec` (cron `0 6 * * 1` per FR-CI-01 verbatim), `project_canonical_domain` (`opendoorph.org` is canonical; `.info`/`.net`/`.com` redirect to it per DEC-2026-05-03-001)

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/canonical.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/canonical.test.mjs
@@ -1,0 +1,178 @@
+/**
+ * T-I-01 - canonical-from-mock-curl integration test.
+ *
+ * Mocks the curl + body-fetch transports via dependency-injection (the
+ * runCanonical subcommand accepts `runCurl` and `fetchBody` overrides).
+ * Scenarios per FR-CANON-01..03:
+ *   - All four chains end at .org via 301 redirect → exit 0
+ *   - .org returns 200 directly (acceptable) → exit 0
+ *   - Sister domain returns 200 with <link rel=canonical>=.org (posture b)
+ *     → exit 0
+ *   - One chain returns a parking page → exit 1
+ *   - One chain throws ENOTFOUND → exit 2 (transport-class outranks fail)
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runCanonical, parseCurlChain, extractCanonicalHref } from '../lib/canonical.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, 'fixtures');
+
+const ALL_GREEN_FIXTURE = readFileSync(join(FIXTURES, 'curl-301-to-org.txt'), 'utf8');
+const ORG_200_FIXTURE = readFileSync(join(FIXTURES, 'curl-org-200.txt'), 'utf8');
+const PARKING_FIXTURE = readFileSync(join(FIXTURES, 'curl-200-parking.txt'), 'utf8');
+
+async function captureStdout(fn) {
+    const realWrite = process.stdout.write.bind(process.stdout);
+    let captured = '';
+    process.stdout.write = (chunk) => {
+        captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+        return true;
+    };
+    try {
+        const code = await fn();
+        return { code, stdout: captured };
+    } finally {
+        process.stdout.write = realWrite;
+    }
+}
+
+describe('canonical subcommand integration', () => {
+    test('all four chains end at .org → exit 0; four PASS lines', async () => {
+        const { code, stdout } = await captureStdout(() => runCanonical(
+            { flags: {}, argv: ['canonical'] },
+            {
+                runCurl: (url) => {
+                    if (url === 'https://opendoorph.org/') return ORG_200_FIXTURE;
+                    return ALL_GREEN_FIXTURE;
+                },
+            },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('PASS canonical: opendoorph.info → https://opendoorph.org/');
+        expect(stdout).toContain('PASS canonical: opendoorph.net → https://opendoorph.org/');
+        expect(stdout).toContain('PASS canonical: opendoorph.com → https://opendoorph.org/');
+        expect(stdout).toContain('PASS canonical: opendoorph.org → https://opendoorph.org/');
+        expect(stdout).toMatch(/SUMMARY canonical exit=0 pass=4 fail=0 warn=0 error=0/);
+        expect(stdout).toContain('EXIT: 0');
+    });
+
+    test('posture (b): sister domain returns 200 with <link rel=canonical>=.org → exit 0', async () => {
+        const html200WithCanonical = `<!doctype html><html><head><link rel="canonical" href="https://opendoorph.org/"><title>X</title></head><body></body></html>`;
+        const { code, stdout } = await captureStdout(() => runCanonical(
+            { flags: {}, argv: ['canonical'] },
+            {
+                runCurl: (url) => {
+                    if (url === 'https://opendoorph.org/') return ORG_200_FIXTURE;
+                    // Sister domains: 200 directly, no Location header.
+                    return ORG_200_FIXTURE;
+                },
+                fetchBody: async () => html200WithCanonical,
+            },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('PASS canonical: opendoorph.info → 200 with <link rel=canonical>=https://opendoorph.org/');
+        expect(stdout).toMatch(/SUMMARY canonical exit=0 pass=4 fail=0 warn=0 error=0/);
+    });
+
+    test('posture (b): sister domain 200 with WRONG canonical → exit 1', async () => {
+        const html200BadCanonical = `<!doctype html><html><head><link rel="canonical" href="https://other.example/"><title>X</title></head><body></body></html>`;
+        const { code, stdout } = await captureStdout(() => runCanonical(
+            { flags: {}, argv: ['canonical'] },
+            {
+                runCurl: () => ORG_200_FIXTURE,
+                fetchBody: async (url) => {
+                    if (url === 'https://opendoorph.org/') return '<html><link rel="canonical" href="https://opendoorph.org/"></html>';
+                    return html200BadCanonical;
+                },
+            },
+        ));
+        expect(code).toBe(1);
+        expect(stdout).toContain('FAIL canonical: opendoorph.info → 200 but <link rel=canonical>=https://other.example/ expected=https://opendoorph.org/');
+    });
+
+    test('one parking-page mismatch → exit 1; all four still walked', async () => {
+        const { code, stdout } = await captureStdout(() => runCanonical(
+            { flags: {}, argv: ['canonical'] },
+            {
+                runCurl: (url) => {
+                    if (url === 'https://opendoorph.net/') return PARKING_FIXTURE;
+                    if (url === 'https://opendoorph.org/') return ORG_200_FIXTURE;
+                    return ALL_GREEN_FIXTURE;
+                },
+            },
+        ));
+        expect(code).toBe(1);
+        expect(stdout).toContain('PASS canonical: opendoorph.info');
+        expect(stdout).toContain('FAIL canonical: opendoorph.net → https://example-parking.example/ expected=https://opendoorph.org/');
+        expect(stdout).toContain('PASS canonical: opendoorph.com');
+        expect(stdout).toContain('PASS canonical: opendoorph.org');
+        expect(stdout).toMatch(/SUMMARY canonical exit=1 pass=3 fail=1 warn=0 error=0/);
+    });
+
+    test('one ENOTFOUND → exit 2; transport-class outranks expected-class', async () => {
+        const enotfound = Object.assign(new Error('curl: (6) Could not resolve host (ENOTFOUND)'), { code: 'ENOTFOUND' });
+        const { code, stdout } = await captureStdout(() => runCanonical(
+            { flags: {}, argv: ['canonical'] },
+            {
+                runCurl: (url) => {
+                    if (url === 'https://opendoorph.com/') throw enotfound;
+                    if (url === 'https://opendoorph.org/') return ORG_200_FIXTURE;
+                    return ALL_GREEN_FIXTURE;
+                },
+            },
+        ));
+        expect(code).toBe(2);
+        expect(stdout).toContain('ERROR canonical: opendoorph.com unreachable cause=ENOTFOUND');
+        expect(stdout).toMatch(/SUMMARY canonical exit=2 pass=3 fail=0 warn=0 error=1/);
+        expect(stdout).toContain('EXIT: 2');
+    });
+
+    test('mixed FAIL + ERROR → exit 2 (transport outranks expected)', async () => {
+        const enotfound = Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+        const { code } = await captureStdout(() => runCanonical(
+            { flags: {}, argv: ['canonical'] },
+            {
+                runCurl: (url) => {
+                    if (url === 'https://opendoorph.net/') return PARKING_FIXTURE;
+                    if (url === 'https://opendoorph.com/') throw enotfound;
+                    if (url === 'https://opendoorph.org/') return ORG_200_FIXTURE;
+                    return ALL_GREEN_FIXTURE;
+                },
+            },
+        ));
+        expect(code).toBe(2);
+    });
+});
+
+describe('canonical helpers', () => {
+    test('parseCurlChain walks status lines and the last Location header', () => {
+        const result = parseCurlChain(ALL_GREEN_FIXTURE);
+        expect(result.chain).toEqual(['301', '200']);
+        expect(result.finalUrl).toBe('https://opendoorph.org/');
+    });
+
+    test('parseCurlChain handles a 200 with no redirect (returns null finalUrl)', () => {
+        const result = parseCurlChain(ORG_200_FIXTURE);
+        expect(result.chain).toEqual(['200']);
+        expect(result.finalUrl).toBe(null);
+        expect(result.lastStatus).toBe(200);
+    });
+
+    test('extractCanonicalHref reads rel-then-href shape', () => {
+        const html = '<link rel="canonical" href="https://opendoorph.org/">';
+        expect(extractCanonicalHref(html)).toBe('https://opendoorph.org/');
+    });
+
+    test('extractCanonicalHref reads href-then-rel shape', () => {
+        const html = '<link href="https://opendoorph.org/" rel="canonical">';
+        expect(extractCanonicalHref(html)).toBe('https://opendoorph.org/');
+    });
+
+    test('extractCanonicalHref returns null when absent', () => {
+        expect(extractCanonicalHref('<html><head></head></html>')).toBe(null);
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/exit-codes.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/exit-codes.test.mjs
@@ -1,0 +1,92 @@
+/**
+ * T-U-02 — exit-code derivation table.
+ *
+ * Asserts FR-CLI-02: every literal `process.exit(N)` in the seo-monitor
+ * source uses N ∈ {0, 1, 2}. Plus a synthetic test of the `all` composition:
+ *   bitwise-OR of (S1..S4) over the legal 4-tuple matrix produces only
+ *   {0, 1, 2, 3} per cli-ux-spec.md §2.1.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = join(HERE, '..');
+
+function stripComments(text) {
+    // Remove block comments first.
+    const noBlock = text.replace(/\/\*[\s\S]*?\*\//g, '');
+    // Then line comments. Naive (does not respect strings) but sufficient
+    // for our small ESM source layer where no string literal contains '//'.
+    return noBlock.replace(/\/\/[^\n]*/g, '');
+}
+
+function* walkSource(root) {
+    for (const name of readdirSync(root)) {
+        if (name === '__tests__' || name === 'node_modules' || name === '.cache') continue;
+        const path = join(root, name);
+        const s = statSync(path);
+        if (s.isDirectory()) {
+            yield* walkSource(path);
+        } else if (/\.(mjs|cjs|js)$/.test(name)) {
+            yield path;
+        }
+    }
+}
+
+describe('exit-code derivation', () => {
+    test('every process.exit() literal in source uses N in {0, 1, 2}', () => {
+        const offenders = [];
+        for (const path of walkSource(SRC_ROOT)) {
+            const text = readFileSync(path, 'utf8');
+            // Strip /* ... */ block comments and // ... line comments before
+            // scanning so JSDoc references to `process.exit(3)` (which appear
+            // in module-level comments documenting the all-composition) do
+            // not register as code-side offenders.
+            const stripped = stripComments(text);
+            const re = /process\.exit\(\s*(\d+)\s*\)/g;
+            let m;
+            while ((m = re.exec(stripped)) !== null) {
+                const n = Number(m[1]);
+                if (n !== 0 && n !== 1 && n !== 2) {
+                    offenders.push(`${path}:${n}`);
+                }
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    test('all-composition bitwise-OR over (S1..S4) matrix', () => {
+        // (canonical, schema, lighthouse, rich-results) — rich-results always 0.
+        const cases = [
+            { sub: [0, 0, 0, 0], expected: 0 },
+            { sub: [1, 0, 0, 0], expected: 1 },
+            { sub: [0, 1, 0, 0], expected: 1 },
+            { sub: [0, 0, 1, 0], expected: 1 },
+            { sub: [0, 2, 0, 0], expected: 2 },
+            { sub: [2, 0, 0, 0], expected: 2 },
+            { sub: [0, 0, 2, 0], expected: 2 },
+            { sub: [1, 2, 0, 0], expected: 3 },
+            { sub: [0, 1, 2, 0], expected: 3 },
+            { sub: [1, 1, 1, 0], expected: 1 },
+            { sub: [2, 2, 2, 0], expected: 2 },
+        ];
+        for (const { sub, expected } of cases) {
+            const composed = sub.reduce((acc, n) => acc | n, 0);
+            expect(composed).toBe(expected);
+        }
+    });
+
+    test('only legal exit codes ever surface from `all` composition', () => {
+        const legal = new Set([0, 1, 2, 3]);
+        for (let a = 0; a < 3; a += 1) {
+            for (let b = 0; b < 3; b += 1) {
+                for (let c = 0; c < 3; c += 1) {
+                    const composed = a | b | c | 0;
+                    expect(legal.has(composed)).toBe(true);
+                }
+            }
+        }
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/extract-nap-shim.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/extract-nap-shim.test.mjs
@@ -1,0 +1,72 @@
+/**
+ * T-U-06 - extract-NAP shim lockstep test.
+ *
+ * Per D-5 the seo-monitor script layer cannot import the .ts source directly
+ * (NFR-01 plain-Node-JS rule); instead it uses a tiny .cjs shim that
+ * re-implements the small surface verbatim. This test asserts the shim
+ * produces byte-identical outputs to the slice-A precedent
+ * (OpenDoorWebsiteApp/src/__tests__/napByteMatch.test.ts) for the
+ * streetAddress + postalCode + telephone tuple.
+ *
+ * If src/utils/extractNAP.ts changes its STREET_RE / ZIP_RE / PHONE_RE,
+ * this test will fail until the shim is updated in the same PR.
+ */
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, 'fixtures');
+
+const require = createRequire(import.meta.url);
+const shim = require('../lib/extractNAPShim.cjs');
+
+describe('extract-nap shim lockstep with src/utils/extractNAP.ts', () => {
+    test('exports the locked surface (normalize, extractNAPFromHtml, buildNAPTuple)', () => {
+        expect(typeof shim.normalize).toBe('function');
+        expect(typeof shim.extractNAPFromHtml).toBe('function');
+        expect(typeof shim.buildNAPTuple).toBe('function');
+    });
+
+    test('normalize matches the .ts contract (NFC + collapse ws + strip commas + trim)', () => {
+        // Mirrors the slice-A FR-05.1 examples.
+        expect(shim.normalize('  135 S 1st St, ')).toBe('135 S 1st St');
+        expect(shim.normalize('Pleasant   Hill,   MO')).toBe('Pleasant Hill MO');
+        expect(shim.normalize('  64080  ')).toBe('64080');
+        expect(shim.normalize('1 2 3, 4 5')).toBe('1 2 3 4 5');
+    });
+
+    test('extractNAPFromHtml prefers <address> over the full body', () => {
+        const html = readFileSync(join(FIXTURES, 'index-with-jsonld.html'), 'utf8');
+        const nap = shim.extractNAPFromHtml(html);
+        expect(nap.street).toBe('135 S 1st St');
+        expect(nap.postalCode).toBe('64080');
+        expect(nap.telephone).toBeNull();
+    });
+
+    test('buildNAPTuple joins non-null fields with single space; drops nulls', () => {
+        expect(shim.buildNAPTuple({ street: '135 S 1st St', postalCode: '64080', telephone: null })).toBe('135 S 1st St 64080');
+        expect(shim.buildNAPTuple({ street: '135 S 1st St', postalCode: '64080', telephone: '(816) 555-1234' })).toBe('135 S 1st St 64080 (816) 555-1234');
+        expect(shim.buildNAPTuple({ street: null, postalCode: null, telephone: null })).toBe('');
+    });
+
+    test('schema-side-vs-rendered byte-equality holds against the fixture', () => {
+        const html = readFileSync(join(FIXTURES, 'index-with-jsonld.html'), 'utf8');
+        const renderedTuple = shim.buildNAPTuple(shim.extractNAPFromHtml(html));
+        const schemaSide = {
+            street: shim.normalize('135 S 1st St'),
+            postalCode: shim.normalize('64080'),
+            telephone: null,
+        };
+        const schemaTuple = shim.buildNAPTuple(schemaSide);
+        expect(renderedTuple).toBe(schemaTuple);
+    });
+
+    test('byte-mismatch surfaces (negative case)', () => {
+        const renderedTuple = shim.buildNAPTuple({ street: '135 S First St', postalCode: '64080', telephone: null });
+        const schemaTuple = shim.buildNAPTuple({ street: '135 S 1st St', postalCode: '64080', telephone: null });
+        expect(renderedTuple).not.toBe(schemaTuple);
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/curl-200-parking.txt
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/curl-200-parking.txt
@@ -1,0 +1,6 @@
+HTTP/2 200
+Server: nginx
+Date: Mon, 09 May 2026 12:00:00 GMT
+Content-Type: text/html
+Location: https://example-parking.example/
+

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/curl-200-with-canonical.txt
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/curl-200-with-canonical.txt
@@ -1,0 +1,6 @@
+HTTP/2 200
+Server: AmazonS3
+Date: Mon, 09 May 2026 12:00:00 GMT
+Content-Type: text/html
+Location: https://opendoorph.org/
+

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/curl-301-to-org.txt
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/curl-301-to-org.txt
@@ -1,0 +1,11 @@
+HTTP/2 301
+Server: cloudflare
+Date: Mon, 09 May 2026 12:00:00 GMT
+Content-Type: text/html
+Location: https://opendoorph.org/
+
+HTTP/2 200
+Server: AmazonS3
+Date: Mon, 09 May 2026 12:00:00 GMT
+Content-Type: text/html
+

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/curl-org-200.txt
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/curl-org-200.txt
@@ -1,0 +1,5 @@
+HTTP/2 200
+Server: AmazonS3
+Date: Mon, 09 May 2026 12:00:00 GMT
+Content-Type: text/html
+

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/index-with-jsonld-selfloop.html
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/index-with-jsonld-selfloop.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Open Door Full Gospel Church — Pleasant Hill, MO</title>
+  <link rel="canonical" href="https://opendoorph.org/">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": ["Church", "LocalBusiness"],
+    "name": "Open Door Full Gospel Church",
+    "url": "https://opendoorph.org/",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "135 S 1st St",
+      "addressLocality": "Pleasant Hill",
+      "addressRegion": "MO",
+      "postalCode": "64080",
+      "addressCountry": "US"
+    },
+    "sameAs": [
+      "https://opendoorph.org/",
+      "https://opendoorph.info/",
+      "https://opendoorph.net/",
+      "https://opendoorph.com/",
+      "https://www.facebook.com/profile.php?id=100064858415448"
+    ]
+  }
+  </script>
+</head>
+<body>
+  <address>
+    135 S 1st St
+    Pleasant Hill, MO 64080
+  </address>
+</body>
+</html>

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/index-with-jsonld.html
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/fixtures/index-with-jsonld.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Open Door Full Gospel Church — Pleasant Hill, MO</title>
+  <link rel="canonical" href="https://opendoorph.org/">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": ["Church", "LocalBusiness"],
+    "name": "Open Door Full Gospel Church",
+    "url": "https://opendoorph.org/",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "135 S 1st St",
+      "addressLocality": "Pleasant Hill",
+      "addressRegion": "MO",
+      "postalCode": "64080",
+      "addressCountry": "US"
+    },
+    "sameAs": [
+      "https://www.facebook.com/profile.php?id=100064858415448"
+    ]
+  }
+  </script>
+</head>
+<body>
+  <h1>Open Door Full Gospel Church</h1>
+  <address>
+    135 S 1st St
+    Pleasant Hill, MO 64080
+  </address>
+</body>
+</html>

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/milestone-marker.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/milestone-marker.test.mjs
@@ -1,0 +1,43 @@
+/**
+ * T-U-03 — MILESTONE_DAY= last-line marker shape.
+ *
+ * The regex shape `^MILESTONE_DAY=(30|60|90|none)$` is locked verbatim in:
+ *   - cli-ux-spec.md §10 glossary
+ *   - this source's lib/rankDue.mjs (exported as MILESTONE_MARKER_REGEX)
+ *   - the README "Output format" section (Ezra fills at S-10)
+ *
+ * The last line of every rank-due block MUST match this regex; the workflow's
+ * milestone-comment trigger (FR-CI-04 / deploy-plan §2.2) keys off the grep.
+ */
+
+import { MILESTONE_MARKER_REGEX } from '../lib/rankDue.mjs';
+
+describe('milestone marker shape', () => {
+    test('regex source is the locked glossary form', () => {
+        expect(MILESTONE_MARKER_REGEX.source).toBe('^MILESTONE_DAY=(30|60|90|none)$');
+    });
+
+    test.each([
+        ['MILESTONE_DAY=30',   '30'],
+        ['MILESTONE_DAY=60',   '60'],
+        ['MILESTONE_DAY=90',   '90'],
+        ['MILESTONE_DAY=none', 'none'],
+    ])('matches %s', (line, expectedGroup) => {
+        const m = MILESTONE_MARKER_REGEX.exec(line);
+        expect(m).not.toBeNull();
+        expect(m[1]).toBe(expectedGroup);
+    });
+
+    test.each([
+        'MILESTONE_DAY=29',
+        'MILESTONE_DAY=31',
+        'MILESTONE_DAY=120',
+        'MILESTONE_DAY= 30',
+        'MILESTONE_DAY=30 ',
+        ' MILESTONE_DAY=30',
+        'milestone_day=30',
+        'INFO MILESTONE_DAY=30',
+    ])('does NOT match %s', (line) => {
+        expect(MILESTONE_MARKER_REGEX.test(line)).toBe(false);
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/no-philippines.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/no-philippines.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * T-U-07 — source-side grep guard for the country token forbidden by NFR-04
+ * memory hot-lesson #1 ("PH = Pleasant Hill, NEVER Philippines").
+ *
+ * Scope:
+ *   - OpenDoorWebsiteApp/scripts/seo-monitor/        (all .mjs / .cjs / .js / .json / .md)
+ *   - .github/workflows/seo-monitor.yml              (the new workflow file)
+ *
+ * The existing slice-A `check-forbidden-strings.sh` covers
+ * OpenDoorWebsiteApp/src/ and public/; this test extends scrutiny to the
+ * NEW utility surface (per orchestrator decision D-9 — three forbidden-string
+ * surfaces, this is the third).
+ *
+ * This file MUST grep for the token but MUST NOT contain the token itself.
+ * We compose the search needle at runtime from harmless ASCII bytes so the
+ * source of this very file reads as "Pleasant Hill, never the Southeast-Asian
+ * island nation" without writing the forbidden word.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_ROOT = resolve(HERE, '..');
+const REPO_ROOT = resolve(HERE, '..', '..', '..', '..');
+const WORKFLOW_PATH = resolve(REPO_ROOT, '.github', 'workflows', 'seo-monitor.yml');
+
+// Compose the forbidden token from harmless bytes so this file does not
+// itself contain the literal string. The token is the lowercased name of
+// the Southeast-Asian island nation (10 letters, ends in "ines").
+const FORBIDDEN_TOKEN = ['p','h','i','l','i','p','p','i','n','e','s'].join('');
+
+function* walkSource(root) {
+    if (!existsSync(root)) return;
+    for (const name of readdirSync(root)) {
+        if (name === 'node_modules' || name === '.cache') continue;
+        // Skip THIS test file (it contains the spelled-out token in the
+        // comment "lowercased name of the Southeast-Asian island nation",
+        // which the runtime grep would otherwise false-flag).
+        if (name === 'no-philippines.test.mjs') continue;
+        const path = join(root, name);
+        const s = statSync(path);
+        if (s.isDirectory()) {
+            yield* walkSource(path);
+        } else if (/\.(mjs|cjs|js|json|md|yml|yaml|txt|html)$/.test(name)) {
+            yield path;
+        }
+    }
+}
+
+describe('no-Philippines source guard (NFR-04, hot-lesson #1)', () => {
+    test('zero hits in OpenDoorWebsiteApp/scripts/seo-monitor/', () => {
+        const offenders = [];
+        for (const path of walkSource(SCRIPT_ROOT)) {
+            const text = readFileSync(path, 'utf8').toLowerCase();
+            if (text.includes(FORBIDDEN_TOKEN)) {
+                offenders.push(path);
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    test('zero hits in .github/workflows/seo-monitor.yml', () => {
+        if (!existsSync(WORKFLOW_PATH)) {
+            // Workflow file is in the same slice; if it does not exist yet
+            // the test passes vacuously (S-08 wires it).
+            return;
+        }
+        const text = readFileSync(WORKFLOW_PATH, 'utf8').toLowerCase();
+        expect(text.includes(FORBIDDEN_TOKEN)).toBe(false);
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/rank-due-dst.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/rank-due-dst.test.mjs
@@ -1,0 +1,48 @@
+/**
+ * T-U-04 — DST-boundary unit test (NFR-08; AC-16).
+ *
+ * Path locked by PRD §13: `__tests__/rank-due-dst.test.mjs`. Plan-stage MAY
+ * NOT silently rename without a PRD §13 cross-update.
+ *
+ * Asserts daysSinceBaseline returns the correct integer across 2026 DST
+ * transitions:
+ *   - Spring-forward: 2026-03-08 (US DST start)
+ *     baseline 2026-02-08 + today 2026-03-10 should equal 30 (NOT 29 or 31).
+ *   - Fall-back: 2026-11-01 (US DST end)
+ *     baseline 2026-10-02 + today 2026-11-01 should equal 30.
+ *
+ * The implementation anchors both endpoints at UTC noon (datetime.mjs)
+ * specifically to neutralize DST drift in the day-count integer.
+ */
+
+import { daysSinceBaseline } from '../lib/datetime.mjs';
+
+describe('rank-due DST-boundary day arithmetic', () => {
+    test('spring-forward 2026-03-08: baseline 2026-02-08 → today 2026-03-10 = 30', () => {
+        expect(daysSinceBaseline('2026-02-08', '2026-03-10')).toBe(30);
+    });
+
+    test('spring-forward boundary: baseline 2026-02-08 → today 2026-03-09 = 29', () => {
+        expect(daysSinceBaseline('2026-02-08', '2026-03-09')).toBe(29);
+    });
+
+    test('spring-forward boundary: baseline 2026-02-08 → today 2026-03-11 = 31', () => {
+        expect(daysSinceBaseline('2026-02-08', '2026-03-11')).toBe(31);
+    });
+
+    test('fall-back 2026-11-01: baseline 2026-10-02 → today 2026-11-01 = 30', () => {
+        expect(daysSinceBaseline('2026-10-02', '2026-11-01')).toBe(30);
+    });
+
+    test('fall-back 2026-11-01: baseline 2026-10-02 → today 2026-10-31 = 29', () => {
+        expect(daysSinceBaseline('2026-10-02', '2026-10-31')).toBe(29);
+    });
+
+    test('fall-back 2026-11-01: baseline 2026-10-02 → today 2026-11-02 = 31', () => {
+        expect(daysSinceBaseline('2026-10-02', '2026-11-02')).toBe(31);
+    });
+
+    test('sanity: far from any DST boundary, midsummer 30-day window', () => {
+        expect(daysSinceBaseline('2026-06-01', '2026-07-01')).toBe(30);
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/rank-due-tz.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/rank-due-tz.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * T-U-05 — Runner-UTC vs America/Chicago disambiguation (AC-38).
+ *
+ * Path locked by PRD §13: `__tests__/rank-due-tz.test.mjs`. Plan-stage MAY
+ * NOT silently rename without a PRD §13 cross-update.
+ *
+ * The runner clock on `ubuntu-latest` is UTC; the cron tick at 06:00 UTC =
+ * 01:00 CDT = STILL the prior day in America/Chicago. If the implementation
+ * uses bare `new Date()` for "today", the milestone fires one day early.
+ *
+ * Contrived case: baseline 2026-04-15, frozen now = 2026-05-15T06:00:00Z.
+ *   - In UTC, today = 2026-05-15 → days_since = 30 → milestone WOULD fire.
+ *   - In America/Chicago, today = 2026-05-15 still maps to 01:00 CDT, which
+ *     is 2026-05-15 in Chicago — wait, 06:00 UTC = 01:00 CDT (CDT = UTC-5
+ *     in May), so the Chicago civil date IS 2026-05-15, and the milestone
+ *     SHOULD fire on that day.
+ *
+ * The truer disambiguation case is BEFORE the local-midnight crossover:
+ * frozen now = 2026-05-15T04:00:00Z = 2026-05-14T23:00:00 CDT — Chicago
+ * is still 2026-05-14 (day-29), UTC is already 2026-05-15 (day-30). The
+ * Chicago civil-date derivation must return 2026-05-14, NOT 2026-05-15.
+ */
+
+import { chicagoCivilDate, daysSinceBaseline } from '../lib/datetime.mjs';
+
+describe('rank-due runner-UTC vs America/Chicago (AC-38)', () => {
+    test('chicagoCivilDate at 2026-05-15T04:00:00Z (= 23:00 CDT prior day) is 2026-05-14', () => {
+        // 2026-05-15T04:00:00Z, May → CDT (UTC-5) → 2026-05-14T23:00:00
+        const utcInstant = new Date('2026-05-15T04:00:00Z');
+        expect(chicagoCivilDate(utcInstant)).toBe('2026-05-14');
+    });
+
+    test('milestone DOES NOT fire when UTC=day-30 but Chicago=day-29', () => {
+        const baselineYmd = '2026-04-15';
+        const utcInstant = new Date('2026-05-15T04:00:00Z'); // 23:00 prior day in CDT
+        const todayChicago = chicagoCivilDate(utcInstant); // 2026-05-14
+
+        const days = daysSinceBaseline(baselineYmd, todayChicago);
+        expect(days).toBe(29); // Chicago side: day 29
+        expect(days).not.toBe(30); // would be 30 if bare new Date() were used
+    });
+
+    test('chicagoCivilDate at 2026-05-15T12:00:00Z (= 07:00 CDT same day) is 2026-05-15', () => {
+        // Sanity: noon UTC on the same calendar day in Chicago is unambiguous.
+        const utcInstant = new Date('2026-05-15T12:00:00Z');
+        expect(chicagoCivilDate(utcInstant)).toBe('2026-05-15');
+    });
+
+    test('milestone DOES fire after Chicago local-midnight crossover', () => {
+        const baselineYmd = '2026-04-15';
+        const utcInstant = new Date('2026-05-15T12:00:00Z'); // 07:00 same day in CDT
+        const todayChicago = chicagoCivilDate(utcInstant); // 2026-05-15
+
+        const days = daysSinceBaseline(baselineYmd, todayChicago);
+        expect(days).toBe(30);
+    });
+
+    test('CST (winter) — chicagoCivilDate at 2026-01-15T05:00:00Z (= 23:00 CST prior day)', () => {
+        // 2026-01-15T05:00:00Z, January → CST (UTC-6) → 2026-01-14T23:00:00
+        const utcInstant = new Date('2026-01-15T05:00:00Z');
+        expect(chicagoCivilDate(utcInstant)).toBe('2026-01-14');
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/rank-due.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/rank-due.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * T-I-03 — rank-due-date-math integration test.
+ *
+ * Per cli-ux-spec.md §1.3, the `--today YYYY-MM-DD` flag injects a
+ * deterministic "today" anchor for testing. Combined with `--baseline-date`
+ * we exercise FR-RANK-01..07 / AC-15..18 without touching the system clock.
+ */
+
+import { runRankDue, RUNBOOK_5_4_QUERIES } from '../lib/rankDue.mjs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT_CONFIG = join(HERE, '..', 'seo-monitor.config.json');
+
+function captureStdout(fn) {
+    const realWrite = process.stdout.write.bind(process.stdout);
+    let captured = '';
+    process.stdout.write = (chunk) => {
+        captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+        return true;
+    };
+    try {
+        const code = fn();
+        return { code, stdout: captured };
+    } finally {
+        process.stdout.write = realWrite;
+    }
+}
+
+function lastLine(stdout) {
+    const lines = stdout.split(/\r?\n/);
+    // Drop the trailing empty line(s).
+    while (lines.length && lines[lines.length - 1] === '') lines.pop();
+    return lines[lines.length - 1];
+}
+
+describe('rank-due subcommand integration', () => {
+    test('day 30 fires; emits four queries + MILESTONE_DAY=30 last line; exit 0', () => {
+        const { code, stdout } = captureStdout(() => runRankDue(
+            {
+                flags: { '--baseline-date': '2026-04-18', '--today': '2026-05-18' },
+                argv: ['rank-due'],
+            },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        for (const q of RUNBOOK_5_4_QUERIES) {
+            expect(stdout).toContain(q);
+        }
+        expect(stdout).toContain('milestone=30');
+        expect(stdout).toContain('SUMMARY rank-due exit=0');
+        expect(stdout).toContain('milestone_day=30');
+        expect(lastLine(stdout)).toBe('MILESTONE_DAY=30');
+    });
+
+    test('day 60 fires', () => {
+        const { code, stdout } = captureStdout(() => runRankDue(
+            {
+                flags: { '--baseline-date': '2026-03-19', '--today': '2026-05-18' },
+                argv: ['rank-due'],
+            },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('milestone=60');
+        expect(lastLine(stdout)).toBe('MILESTONE_DAY=60');
+    });
+
+    test('day 90 fires', () => {
+        const { code, stdout } = captureStdout(() => runRankDue(
+            {
+                flags: { '--baseline-date': '2026-02-17', '--today': '2026-05-18' },
+                argv: ['rank-due'],
+            },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('milestone=90');
+        expect(lastLine(stdout)).toBe('MILESTONE_DAY=90');
+    });
+
+    test('day 31 (non-milestone) silent; MILESTONE_DAY=none last line; exit 0', () => {
+        const { code, stdout } = captureStdout(() => runRankDue(
+            {
+                flags: { '--baseline-date': '2026-04-18', '--today': '2026-05-19' },
+                argv: ['rank-due'],
+            },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        expect(lastLine(stdout)).toBe('MILESTONE_DAY=none');
+        // Non-milestone day without --verbose: no DEBUG line.
+        expect(stdout).not.toContain('DEBUG rank-due:');
+    });
+
+    test('--verbose on non-milestone day emits DEBUG line', () => {
+        const { code, stdout } = captureStdout(() => runRankDue(
+            {
+                flags: { '--baseline-date': '2026-04-18', '--today': '2026-05-19', '--verbose': true },
+                argv: ['rank-due'],
+            },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('DEBUG rank-due: non-milestone day, days-since-baseline=31');
+    });
+
+    test('future baseline → "will arm at" + MILESTONE_DAY=none + exit 0', () => {
+        const { code, stdout } = captureStdout(() => runRankDue(
+            {
+                flags: { '--baseline-date': '2027-01-01', '--today': '2026-05-18' },
+                argv: ['rank-due'],
+            },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('baseline is in the future; will arm at 2027-01-01');
+        expect(lastLine(stdout)).toBe('MILESTONE_DAY=none');
+    });
+
+    test('empty config → "not yet armed" + MILESTONE_DAY=none + exit 0', () => {
+        // Use the repo's actual seo-monitor.config.json (baseline_date = null).
+        const { code, stdout } = captureStdout(() => runRankDue(
+            { flags: { '--today': '2026-05-18' }, argv: ['rank-due'] },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('not yet armed');
+        expect(lastLine(stdout)).toBe('MILESTONE_DAY=none');
+    });
+
+    test('--baseline-date overrides config (single source of truth)', () => {
+        const { code, stdout } = captureStdout(() => runRankDue(
+            {
+                flags: { '--baseline-date': '2026-04-18', '--today': '2026-05-18' },
+                argv: ['rank-due'],
+            },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('baseline=2026-04-18');
+    });
+
+    test('rank-due NEVER fails exit (FR-RANK-07): malformed-shape baseline still exits 0', () => {
+        const { code, stdout } = captureStdout(() => runRankDue(
+            {
+                flags: { '--baseline-date': 'not-a-date', '--today': '2026-05-18' },
+                argv: ['rank-due'],
+            },
+            { configPath: REPO_ROOT_CONFIG },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('WARN rank-due: baseline_date invalid');
+        expect(lastLine(stdout)).toBe('MILESTONE_DAY=none');
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/schema.test.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/__tests__/schema.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * T-I-02 — schema-from-fixture integration test.
+ *
+ * Mocks the fetch transport via dependency-injection (the runSchema
+ * subcommand accepts a `fetchHtml` override). Two scenarios per FR-SCHEMA-01..07:
+ *   - Golden fixture (mirrors public/index.html shape) → all PASS lines, exit 0
+ *   - Self-loop fixture (sameAs has 5 entries) → FAIL on FR-SCHEMA-05, exit 1
+ *   - Mock throws → ERROR, exit 2
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { runSchema, extractJsonLdBlocks, extractCanonicalLinks } from '../lib/schema.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, 'fixtures');
+
+const GOLDEN_HTML = readFileSync(join(FIXTURES, 'index-with-jsonld.html'), 'utf8');
+const SELFLOOP_HTML = readFileSync(join(FIXTURES, 'index-with-jsonld-selfloop.html'), 'utf8');
+
+function captureStdout(asyncFn) {
+    const realWrite = process.stdout.write.bind(process.stdout);
+    let captured = '';
+    process.stdout.write = (chunk) => {
+        captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+        return true;
+    };
+    return Promise.resolve()
+        .then(asyncFn)
+        .then((code) => {
+            process.stdout.write = realWrite;
+            return { code, stdout: captured };
+        })
+        .catch((e) => {
+            process.stdout.write = realWrite;
+            throw e;
+        });
+}
+
+describe('schema subcommand integration', () => {
+    test('golden fixture → all PASS lines, exit 0', async () => {
+        const { code, stdout } = await captureStdout(() => runSchema(
+            { flags: {}, argv: ['schema'] },
+            { fetchHtml: async () => GOLDEN_HTML },
+        ));
+        expect(code).toBe(0);
+        expect(stdout).toContain('PASS schema: ld+json blocks count=1');
+        expect(stdout).toContain('PASS schema: @context value=https://schema.org');
+        expect(stdout).toContain('PASS schema: @type includes=Church');
+        expect(stdout).toContain('PASS schema: url byte-equal=https://opendoorph.org/');
+        expect(stdout).toContain('PASS schema: link rel=canonical href byte-equal=https://opendoorph.org/');
+        expect(stdout).toContain('PASS schema: sameAs length=1 sole=https://www.facebook.com/profile.php?id=100064858415448');
+        expect(stdout).toContain('PASS schema: NAP byte-equal scope=address+phone (DEC-2026-05-03-003)');
+        expect(stdout).toMatch(/SUMMARY schema exit=0 pass=7 fail=0 warn=0 error=0/);
+    });
+
+    test('self-loop fixture → FAIL on sameAs length, exit 1', async () => {
+        const { code, stdout } = await captureStdout(() => runSchema(
+            { flags: {}, argv: ['schema'] },
+            { fetchHtml: async () => SELFLOOP_HTML },
+        ));
+        expect(code).toBe(1);
+        expect(stdout).toContain('FAIL schema: sameAs length expected=1 got=5');
+    });
+
+    test('transport error → exit 2 with ERROR line', async () => {
+        const { code, stdout } = await captureStdout(() => runSchema(
+            { flags: {}, argv: ['schema'] },
+            { fetchHtml: async () => { throw new Error('ECONNREFUSED'); } },
+        ));
+        expect(code).toBe(2);
+        expect(stdout).toContain('ERROR schema: https://opendoorph.org/ unreachable cause=ECONNREFUSED');
+        expect(stdout).toContain('EXIT: 2');
+    });
+});
+
+describe('schema HTML helpers', () => {
+    test('extractJsonLdBlocks returns one block from the golden fixture', () => {
+        const blocks = extractJsonLdBlocks(GOLDEN_HTML);
+        expect(blocks).toHaveLength(1);
+        const parsed = JSON.parse(blocks[0]);
+        expect(parsed['@context']).toBe('https://schema.org');
+        expect(parsed.url).toBe('https://opendoorph.org/');
+    });
+
+    test('extractCanonicalLinks returns the byte-as-written href', () => {
+        const links = extractCanonicalLinks(GOLDEN_HTML);
+        expect(links).toEqual(['https://opendoorph.org/']);
+    });
+
+    test('extractCanonicalLinks handles href-before-rel attribute order', () => {
+        const html = '<link href="https://opendoorph.org/" rel="canonical">';
+        const links = extractCanonicalLinks(html);
+        expect(links).toEqual(['https://opendoorph.org/']);
+    });
+});

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/jest.config.cjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/jest.config.cjs
@@ -1,0 +1,35 @@
+/**
+ * Jest config for the seo-monitor utility tests.
+ *
+ * Spike outcome (S-09 AC-6): Pre-flight Spike 1.1 ran `CI=true npm test --
+ * --testPathPattern=seo-monitor` against a sentinel `_sentinel.test.mjs` and
+ * react-scripts (CRA's Jest wrapper) reported "No tests found" because CRA's
+ * built-in testMatch hard-codes `src/**` with `.{js,jsx,ts,tsx}` only — `.mjs`
+ * outside `src/` is invisible to it. **PASS-B fired.**
+ *
+ * Per orchestrator decision D-1 + stories.md S-09 AC-6, we add this dedicated
+ * Jest config and the `npm run test:seo` package.json entry (the EIGHTH script
+ * in the non-`seo:*` namespace, preserving S-01 AC-6's seven-`seo:*` invariant).
+ *
+ * Jest 27 (transitively via react-scripts 5) supports ESM .mjs natively as
+ * long as we tell it where to look and let the .mjs files be loaded as ES
+ * modules (Node's loader handles that — no Babel transform needed for our
+ * pure-Node code that has no JSX / TS).
+ */
+
+'use strict';
+
+const path = require('path');
+
+module.exports = {
+    rootDir: path.resolve(__dirname, '..', '..'),
+    displayName: 'seo-monitor',
+    testEnvironment: 'node',
+    testMatch: [
+        '<rootDir>/scripts/seo-monitor/__tests__/**/*.test.mjs',
+    ],
+    moduleFileExtensions: ['mjs', 'cjs', 'js', 'json'],
+    transform: {},
+    // Quiet mode for CI: only show test failures by default.
+    verbose: false,
+};

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/all.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/all.mjs
@@ -1,0 +1,110 @@
+/**
+ * `all` subcommand — run S1..S5 in sequence; compose exit code via bitwise-OR
+ * of the FIRST FOUR exits ONLY (FR-CLI-03; rank-due always exits 0 per
+ * FR-RANK-07 and is excluded from the composition).
+ *
+ * Per cli-ux-spec.md §2.1, legal `all` exit codes are:
+ *   0 — all four pass
+ *   1 — at least one expected-class failure (no transport-class)
+ *   2 — at least one transport-class error (no expected-class)
+ *   3 — both classes fired (1 | 2)
+ *
+ * The grand SUMMARY line aggregates pass/fail/warn/error counts across the
+ * five sub-blocks AND surfaces the milestone_day marker for the workflow's
+ * comment-posting step (FR-CI-04).
+ */
+
+import { runCanonical } from './canonical.mjs';
+import { runSchema } from './schema.mjs';
+import { runLighthouse } from './lighthouse.mjs';
+import { runRichResults } from './richResults.mjs';
+import { runRankDue, MILESTONE_MARKER_REGEX } from './rankDue.mjs';
+
+/**
+ * @param {{ flags: Record<string, string|boolean>, argv: string[] }} ctx
+ * @returns {Promise<number>}
+ */
+export async function runAll(ctx) {
+    process.stdout.write(`=== seo-monitor all ===\n`);
+    process.stdout.write(`UTC: ${new Date().toISOString()}\n`);
+    process.stdout.write(`COMMAND: ${ctx.argv.join(' ')}\n`);
+
+    // Capture each subcommand's stdout to derive grand counts and milestone_day.
+    /** @type {{e: number, captured: string}} */
+    const results = { e: 0, captured: '' };
+
+    const captures = [];
+
+    captures.push(await captureStdout(() => runCanonical({ flags: ctx.flags, argv: ['canonical'] })));
+    void results; // results object retained for potential future grand counters; current path uses `captures` only.
+    captures.push(await captureStdout(() => runSchema({ flags: ctx.flags, argv: ['schema'] })));
+    captures.push(await captureStdout(() => runLighthouse({ flags: ctx.flags, argv: ['lighthouse'] })));
+    captures.push(await captureStdout(() => runRichResults({ flags: ctx.flags, argv: ['rich-results'] })));
+    captures.push(await captureStdout(() => runRankDue({ flags: ctx.flags, argv: ['rank-due'] })));
+
+    // Compose exit code: bitwise-OR of the FIRST FOUR ONLY.
+    const exitsForOr = captures.slice(0, 4).map((r) => r.exitCode);
+    const composedExit = exitsForOr.reduce((acc, n) => acc | n, 0);
+
+    // Aggregate counters from the grand log.
+    const allOut = captures.map((r) => r.stdout).join('');
+    const counts = aggregateCounters(allOut);
+    const milestoneDay = detectMilestoneDay(allOut);
+
+    process.stdout.write(
+        `SUMMARY all exit=${composedExit} pass=${counts.pass} fail=${counts.fail} warn=${counts.warn} error=${counts.error} milestone_day=${milestoneDay}\n`,
+    );
+    process.stdout.write(`EXIT: ${composedExit}\n`);
+
+    // Re-emit the rank-due block's MILESTONE_DAY= line as the absolute last
+    // stdout line, so workflow grep targeting end-of-stream still finds it.
+    process.stdout.write(`MILESTONE_DAY=${milestoneDay}\n`);
+
+    return composedExit;
+}
+
+/**
+ * Run a function while capturing its stdout into a string. The captured
+ * stdout is ALSO mirrored to the real stdout so the user sees a live log.
+ *
+ * @param {() => number|Promise<number>} fn
+ * @returns {Promise<{exitCode: number, stdout: string}>}
+ */
+async function captureStdout(fn) {
+    const realWrite = process.stdout.write.bind(process.stdout);
+    let captured = '';
+    /** @type {any} */
+    process.stdout.write = (chunk, encodingOrCb, cb) => {
+        const str = typeof chunk === 'string' ? chunk : Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+        captured += str;
+        return realWrite(chunk, encodingOrCb, cb);
+    };
+    try {
+        const exitCode = await fn();
+        return { exitCode, stdout: captured };
+    } finally {
+        process.stdout.write = realWrite;
+    }
+}
+
+function aggregateCounters(text) {
+    const re = /^SUMMARY \S+ exit=\d+ pass=(\d+) fail=(\d+) warn=(\d+) error=(\d+)/gm;
+    let m;
+    let pass = 0, fail = 0, warn = 0, error = 0;
+    while ((m = re.exec(text)) !== null) {
+        pass += Number(m[1]);
+        fail += Number(m[2]);
+        warn += Number(m[3]);
+        error += Number(m[4]);
+    }
+    return { pass, fail, warn, error };
+}
+
+function detectMilestoneDay(text) {
+    const lines = text.split(/\r?\n/);
+    for (const line of lines) {
+        const m = MILESTONE_MARKER_REGEX.exec(line);
+        if (m) return m[1];
+    }
+    return 'none';
+}

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/argv.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/argv.mjs
@@ -1,0 +1,171 @@
+/**
+ * Minimal long-form-only argv parser.
+ *
+ * Per cli-ux-spec.md §1.3, all flags are long-form (`--flag` or `--flag value`).
+ * Unknown subcommand or flag → USAGE_ERROR (exit 2). No interactive prompts;
+ * stdin is never read.
+ *
+ * Supported flag shapes: `--name value`, `--name=value`, `--bool-flag`.
+ * Boolean flags listed in BOOLEAN_FLAGS take no value.
+ */
+
+const BOOLEAN_FLAGS = new Set([
+    '--help',
+    '--verbose',
+    '--no-color',
+    '--json',
+    '--baseline-write',
+]);
+
+const VALUE_FLAGS = new Set([
+    '--baseline-date',
+    '--today',
+    '--baseline-from',
+    '--target-url',
+    '--timeout-seconds',
+    '--runs',
+    '--config',
+]);
+
+const KNOWN_FLAGS = new Set([...BOOLEAN_FLAGS, ...VALUE_FLAGS]);
+
+const SUBCOMMANDS = ['canonical', 'schema', 'lighthouse', 'rich-results', 'rank-due', 'all'];
+
+/**
+ * @typedef {{
+ *   subcommand: string|null,
+ *   flags: Record<string, string|boolean>,
+ *   positional: string[],
+ *   helpRequested: boolean,
+ *   error: string|null
+ * }} ParsedArgs
+ */
+
+/**
+ * Parse argv (excluding `node` and the script path).
+ *
+ * @param {string[]} argv
+ * @returns {ParsedArgs}
+ */
+export function parseArgs(argv) {
+    /** @type {ParsedArgs} */
+    const out = {
+        subcommand: null,
+        flags: {},
+        positional: [],
+        helpRequested: false,
+        error: null,
+    };
+
+    let i = 0;
+    while (i < argv.length) {
+        const tok = argv[i];
+
+        if (tok === '--help' || tok === '-h') {
+            out.helpRequested = true;
+            i += 1;
+            continue;
+        }
+
+        if (tok.startsWith('--')) {
+            // --name=value form
+            const eq = tok.indexOf('=');
+            if (eq !== -1) {
+                const name = tok.slice(0, eq);
+                const value = tok.slice(eq + 1);
+                if (!KNOWN_FLAGS.has(name)) {
+                    out.error = `unknown flag "${name}"`;
+                    return out;
+                }
+                if (BOOLEAN_FLAGS.has(name)) {
+                    out.error = `flag "${name}" does not take a value`;
+                    return out;
+                }
+                out.flags[name] = value;
+                i += 1;
+                continue;
+            }
+
+            if (!KNOWN_FLAGS.has(tok)) {
+                out.error = `unknown flag "${tok}"`;
+                return out;
+            }
+
+            if (BOOLEAN_FLAGS.has(tok)) {
+                out.flags[tok] = true;
+                i += 1;
+                continue;
+            }
+
+            // VALUE_FLAGS: consume next token as value.
+            const next = argv[i + 1];
+            if (next === undefined || next.startsWith('--')) {
+                out.error = `flag "${tok}" requires a value`;
+                return out;
+            }
+            out.flags[tok] = next;
+            i += 2;
+            continue;
+        }
+
+        // Positional. The first positional is the subcommand.
+        if (out.subcommand === null) {
+            if (!SUBCOMMANDS.includes(tok)) {
+                out.error = `unknown subcommand "${tok}"`;
+                return out;
+            }
+            out.subcommand = tok;
+        } else {
+            out.positional.push(tok);
+        }
+        i += 1;
+    }
+
+    return out;
+}
+
+/** @returns {string[]} */
+export function listSubcommands() {
+    return [...SUBCOMMANDS];
+}
+
+/**
+ * Suggest the closest subcommand by Levenshtein distance.
+ *
+ * @param {string} bad
+ * @returns {string|null}
+ */
+export function suggestSubcommand(bad) {
+    let best = null;
+    let bestDist = Infinity;
+    for (const s of SUBCOMMANDS) {
+        const d = levenshtein(bad, s);
+        if (d < bestDist && d <= 3) {
+            best = s;
+            bestDist = d;
+        }
+    }
+    return best;
+}
+
+function levenshtein(a, b) {
+    const m = a.length;
+    const n = b.length;
+    if (m === 0) return n;
+    if (n === 0) return m;
+    /** @type {number[][]} */
+    const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+    for (let i = 0; i <= m; i += 1) dp[i][0] = i;
+    for (let j = 0; j <= n; j += 1) dp[0][j] = j;
+    for (let i = 1; i <= m; i += 1) {
+        for (let j = 1; j <= n; j += 1) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            dp[i][j] = Math.min(
+                dp[i - 1][j] + 1,
+                dp[i][j - 1] + 1,
+                dp[i - 1][j - 1] + cost,
+            );
+        }
+    }
+    return dp[m][n];
+}

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/canonical.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/canonical.mjs
@@ -1,0 +1,241 @@
+/**
+ * `canonical` subcommand — four-domain redirect-chain posture (FR-CANON-01..03).
+ *
+ * For each of opendoorph.{info,net,com,org}/, runs `curl -sIL` and parses the
+ * response chain. Acceptable postures:
+ *   (a) HTTP 301/302 chain ending at https://opendoorph.org/ (per DEC-2026-05-03-001)
+ *   (b) HTTP 200 with `<link rel=canonical>` to the .org (advisory; we treat 200
+ *       on the .org root itself as the green case).
+ *
+ * Exit semantics (cli-ux-spec.md §2.2):
+ *   - All four chains end at .org → 0
+ *   - Any per-domain MISMATCH → 1 (all four still walked; no first-failure-abort)
+ *   - Any TRANSPORT_ERROR → 2 (outranks 1 if both classes occur, per §4.2)
+ *   - Mixed FAIL + ERROR → 2 (transport-class outranks expected-class)
+ */
+
+import { execSync } from 'node:child_process';
+
+import { EXIT_PASS, EXIT_FAIL, EXIT_ERROR } from './exitCodes.mjs';
+import { openBlock, closeBlock, pass, fail, info, error, raw } from './output.mjs';
+
+const SUBCMD = 'canonical';
+const DEFAULT_TIMEOUT_S = 10;
+const DOMAINS = [
+    'opendoorph.info',
+    'opendoorph.net',
+    'opendoorph.com',
+    'opendoorph.org',
+];
+const EXPECTED_FINAL = 'https://opendoorph.org/';
+
+/**
+ * Run the subcommand. Returns the exit code (caller calls process.exit).
+ *
+ * @param {{ flags: Record<string, string|boolean>, argv: string[] }} ctx
+ * @param {{
+ *   runCurl?: (url: string, timeoutSec: number) => string,
+ *   fetchBody?: (url: string, timeoutSec: number) => Promise<string>
+ * }} [deps]
+ * @returns {Promise<number>}
+ */
+export async function runCanonical(ctx, deps = {}) {
+    const c = openBlock(SUBCMD, ctx.argv);
+    const timeoutSec = parseInt(/** @type {string} */ (ctx.flags['--timeout-seconds']) || `${DEFAULT_TIMEOUT_S}`, 10);
+    info(SUBCMD, `probing ${DOMAINS.length} domains timeout_s=${timeoutSec}`);
+
+    const runCurl = deps.runCurl || defaultRunCurl;
+    const fetchBody = deps.fetchBody || defaultFetchBody;
+
+    let sawFail = false;
+    let sawError = false;
+
+    for (const domain of DOMAINS) {
+        const url = `https://${domain}/`;
+        try {
+            const headers = runCurl(url, timeoutSec);
+            const result = parseCurlChain(headers);
+            const finalUrl = result.finalUrl || url;
+            const chain = result.chain.join(',') || `${result.lastStatus}`;
+
+            if (finalUrl === EXPECTED_FINAL) {
+                pass(SUBCMD, `${domain} → ${EXPECTED_FINAL} chain=${chain}`, c);
+                continue;
+            }
+
+            // Posture (b) per FR-CANON-01: 200 with <link rel=canonical> to
+            // the .org. The .org root itself satisfies posture (b) trivially
+            // (final URL == expected). For sister domains served identical
+            // HTML out of S3/CloudFront, fetch the body and verify the
+            // canonical link points home.
+            if (result.lastStatus === 200 && finalUrl === url) {
+                try {
+                    const body = await fetchBody(url, timeoutSec);
+                    const canonicalHref = extractCanonicalHref(body);
+                    if (canonicalHref === EXPECTED_FINAL) {
+                        pass(
+                            SUBCMD,
+                            `${domain} → 200 with <link rel=canonical>=${EXPECTED_FINAL} chain=${chain}`,
+                            c,
+                        );
+                        continue;
+                    }
+                    fail(
+                        SUBCMD,
+                        `${domain} → 200 but <link rel=canonical>=${canonicalHref ?? '(absent)'} expected=${EXPECTED_FINAL}`,
+                        c,
+                    );
+                    sawFail = true;
+                    continue;
+                } catch (bodyErr) {
+                    const cause = classifyError(bodyErr);
+                    error(
+                        SUBCMD,
+                        `${domain} body fetch failed cause=${cause} timeout_s=${timeoutSec}`,
+                        c,
+                    );
+                    sawError = true;
+                    continue;
+                }
+            }
+
+            fail(
+                SUBCMD,
+                `${domain} → ${finalUrl} expected=${EXPECTED_FINAL}`,
+                c,
+            );
+            sawFail = true;
+        } catch (e) {
+            const cause = classifyError(e);
+            error(
+                SUBCMD,
+                `${domain} unreachable cause=${cause} timeout_s=${timeoutSec}`,
+                c,
+            );
+            sawError = true;
+        }
+    }
+
+    let exitCode = EXIT_PASS;
+    if (sawError) {
+        exitCode = EXIT_ERROR; // transport-class outranks expected-class (§4.2)
+    } else if (sawFail) {
+        exitCode = EXIT_FAIL;
+    }
+
+    closeBlock(SUBCMD, exitCode, c);
+    return exitCode;
+}
+
+/**
+ * Default transport — shells out to curl. Returns the raw header text on success;
+ * throws on transport failure (non-zero curl exit).
+ *
+ * @param {string} url
+ * @param {number} timeoutSec
+ * @returns {string}
+ */
+function defaultRunCurl(url, timeoutSec) {
+    return execSync(
+        `curl -sIL --max-time ${timeoutSec} ${shellQuote(url)}`,
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+}
+
+/**
+ * Default body fetch via Node 18+ built-in fetch. Used for posture (b)
+ * verification when a sister domain returns 200 instead of a 301.
+ *
+ * @param {string} url
+ * @param {number} timeoutSec
+ * @returns {Promise<string>}
+ */
+async function defaultFetchBody(url, timeoutSec) {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), timeoutSec * 1000);
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) {
+            throw new Error(`HTTP ${res.status}`);
+        }
+        return await res.text();
+    } finally {
+        clearTimeout(t);
+    }
+}
+
+/**
+ * Extract the first <link rel="canonical"> href from raw HTML. Returns null
+ * if absent. Accepts attribute order rel-then-href and href-then-rel.
+ *
+ * @param {string} html
+ * @returns {string|null}
+ */
+export function extractCanonicalHref(html) {
+    const re1 = /<link\b[^>]*\brel=["']canonical["'][^>]*\bhref=["']([^"']+)["']/i;
+    const m1 = re1.exec(html);
+    if (m1) return m1[1];
+    const re2 = /<link\b[^>]*\bhref=["']([^"']+)["'][^>]*\brel=["']canonical["']/i;
+    const m2 = re2.exec(html);
+    if (m2) return m2[1];
+    return null;
+}
+
+function shellQuote(s) {
+    // Whitelist: schemes/hosts/paths can contain alphanumerics, dots, slashes,
+    // colons, hyphens, percent-encoded bytes. Anything else gets single-quoted.
+    if (/^[A-Za-z0-9.\-_/:%?&=]+$/.test(s)) return s;
+    return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Parse `curl -sIL` output. Walks all HTTP status lines and Location headers
+ * to determine the final URL and the chain of statuses.
+ *
+ * @param {string} headers
+ * @returns {{ finalUrl: string|null, chain: string[], lastStatus: number }}
+ */
+export function parseCurlChain(headers) {
+    /** @type {string[]} */
+    const chain = [];
+    let lastLocation = null;
+    let lastStatus = 0;
+
+    const lines = headers.split(/\r?\n/);
+    for (const line of lines) {
+        const statusMatch = /^HTTP\/[\d.]+\s+(\d{3})/.exec(line);
+        if (statusMatch) {
+            const code = Number(statusMatch[1]);
+            chain.push(String(code));
+            lastStatus = code;
+            continue;
+        }
+        const locMatch = /^[Ll]ocation:\s*(\S+)/.exec(line);
+        if (locMatch) {
+            lastLocation = locMatch[1].trim();
+        }
+    }
+
+    // Final URL is the last Location header if any (curl -L follows them);
+    // otherwise we cannot know — caller treats null as "stayed at requested URL".
+    return {
+        finalUrl: lastLocation,
+        chain,
+        lastStatus,
+    };
+}
+
+function classifyError(e) {
+    const msg = String((e && e.message) || e || '');
+    if (/ENOTFOUND/i.test(msg)) return 'ENOTFOUND';
+    if (/ECONNREFUSED/i.test(msg)) return 'ECONNREFUSED';
+    if (/ETIMEDOUT/i.test(msg) || /timed out/i.test(msg)) return 'ETIMEDOUT';
+    if (/SSL|TLS|certificate/i.test(msg)) return 'TLS_ERROR';
+    // Curl exit codes surface as "Command failed: ..." — extract first word that helps.
+    const m = /\bcurl:\s*\(\d+\)\s*([^\n]+)/.exec(msg);
+    if (m) return m[1].trim().slice(0, 80).replace(/\s+/g, '_');
+    return 'CURL_ERROR';
+}
+
+// For CWD-independent use by `all`.
+export const subcommandName = SUBCMD;

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/config.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/config.mjs
@@ -1,0 +1,58 @@
+/**
+ * Config loader for seo-monitor.
+ *
+ * Behavior contract (FR-RANK-03 / AC-17 / AC-18):
+ *   - Empty / null / missing-file → return { baseline_date: null, ... } sentinel.
+ *   - Malformed JSON:
+ *       - For non-rank-due callers: throw a SyntaxError so the caller can exit 2.
+ *       - For rank-due callers: catch upstream and treat as empty (FR-RANK-07).
+ *   - Valid JSON: return the parsed object.
+ *
+ * Default config path: <repo>/OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.config.json
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Default JSON config path (same dir as the entry point's parent). */
+export const DEFAULT_CONFIG_PATH = resolve(HERE, '..', 'seo-monitor.config.json');
+
+/**
+ * @typedef {{
+ *   baseline_date: (string|null),
+ *   lighthouse_baseline?: { seo: number|null, accessibility: number|null, performance: number|null, best_practices: number|null },
+ *   canonical_domain?: string
+ * }} SeoConfig
+ */
+
+/** @returns {SeoConfig} */
+export function emptyConfig() {
+    return {
+        baseline_date: null,
+        lighthouse_baseline: { seo: null, accessibility: null, performance: null, best_practices: null },
+        canonical_domain: 'opendoorph.org',
+    };
+}
+
+/**
+ * Load config from disk. Throws on malformed JSON; the rank-due caller
+ * catches and treats as empty per FR-RANK-07.
+ *
+ * @param {string} [path]
+ * @returns {SeoConfig}
+ */
+export function loadConfig(path = DEFAULT_CONFIG_PATH) {
+    if (!existsSync(path)) {
+        return emptyConfig();
+    }
+    const raw = readFileSync(path, 'utf8');
+    if (raw.trim() === '') {
+        return emptyConfig();
+    }
+    /** @type {Partial<SeoConfig>} */
+    const parsed = JSON.parse(raw); // may throw SyntaxError — caller decides
+    return { ...emptyConfig(), ...parsed };
+}

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/datetime.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/datetime.mjs
@@ -1,0 +1,75 @@
+/**
+ * Date/time helpers for the rank-due milestone arithmetic.
+ *
+ * The PRD (FR-RANK-02 / NFR-08 / AC-16 / AC-38) requires both endpoints
+ * (baseline + today) to be derived in `America/Chicago` local civil-date,
+ * NOT in UTC. The runner clock on `ubuntu-latest` is UTC; bare `new Date()`
+ * for "today" would silently fire the milestone one day early when the cron
+ * tick lands at 06:00 UTC (= 01:00 CDT, still day-N-1 in Chicago).
+ *
+ * We use `Intl.DateTimeFormat('en-CA', { timeZone: 'America/Chicago' })` to
+ * derive a stable YYYY-MM-DD on both sides, then subtract via UTC anchors so
+ * the day-count is DST-safe.
+ */
+
+/**
+ * Civil-date string YYYY-MM-DD in America/Chicago for the given Date.
+ * `en-CA` locale is chosen because it formats as YYYY-MM-DD by default.
+ *
+ * @param {Date} d
+ * @returns {string}
+ */
+export function chicagoCivilDate(d) {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'America/Chicago',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    });
+    return fmt.format(d);
+}
+
+/**
+ * Parse a YYYY-MM-DD string into UTC-noon Date (avoids DST midnight ambiguity
+ * when subtracting two civil dates as days).
+ *
+ * Throws if the input is not a valid YYYY-MM-DD or names an impossible date.
+ *
+ * @param {string} ymd
+ * @returns {Date}
+ */
+export function civilDateToUtcNoon(ymd) {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd);
+    if (!m) {
+        throw new Error(`invalid YYYY-MM-DD: ${ymd}`);
+    }
+    const y = Number(m[1]);
+    const mo = Number(m[2]);
+    const d = Number(m[3]);
+    // Use UTC noon as the anchor to keep day-arithmetic stable across DST.
+    const date = new Date(Date.UTC(y, mo - 1, d, 12, 0, 0));
+    if (
+        date.getUTCFullYear() !== y ||
+        date.getUTCMonth() !== mo - 1 ||
+        date.getUTCDate() !== d
+    ) {
+        throw new Error(`invalid calendar date: ${ymd}`);
+    }
+    return date;
+}
+
+/**
+ * Days between two civil-date strings (today - baseline). Both arguments
+ * are YYYY-MM-DD; we anchor at UTC noon so DST transitions cannot perturb
+ * the integer count.
+ *
+ * @param {string} baselineYmd
+ * @param {string} todayYmd
+ * @returns {number}
+ */
+export function daysSinceBaseline(baselineYmd, todayYmd) {
+    const a = civilDateToUtcNoon(baselineYmd);
+    const b = civilDateToUtcNoon(todayYmd);
+    const ms = b.getTime() - a.getTime();
+    return Math.round(ms / (24 * 60 * 60 * 1000));
+}

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/exitCodes.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/exitCodes.mjs
@@ -1,0 +1,19 @@
+/**
+ * Exit-code dialect for the seo-monitor utility.
+ *
+ * Mirrors `OpenDoorWebsiteApp/scripts/check-forbidden-strings.sh` lines 27-31:
+ *   0 = pass / informational
+ *   1 = expected-class failure (assertion fired)
+ *   2 = config error / unexpected (transport, USAGE_ERROR, missing binary)
+ *
+ * The `all` subcommand composes via bitwise-OR of S1..S4 only — `rank-due`
+ * always exits 0 (FR-RANK-07) and is excluded from composition (FR-CLI-03).
+ *
+ * NEVER add a fourth exit code. AC-20 / FR-CLI-02 grep the source for
+ * `process.exit(` and assert only {0, 1, 2} appear (and `process.exit(3)`
+ * derived purely as the bitwise-OR composition of `all`, never as a literal).
+ */
+
+export const EXIT_PASS = 0;
+export const EXIT_FAIL = 1;
+export const EXIT_ERROR = 2;

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/extractNAPShim.cjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/extractNAPShim.cjs
@@ -1,0 +1,70 @@
+/**
+ * D-5 shim — re-exports the surface of `OpenDoorWebsiteApp/src/utils/extractNAP.ts`.
+ *
+ * The .ts source lives under src/ and is compiled by `tsc` for the CRA build,
+ * but the seo-monitor script layer is plain Node JS (NFR-01) and cannot import
+ * the .ts file directly. This shim re-implements the small surface in plain JS,
+ * derived line-by-line from the .ts source. The `extract-nap-shim.test.mjs`
+ * lockstep test asserts the shim's outputs match the .ts source's expected
+ * outputs against the slice-A `napByteMatch.test.ts` fixture pattern.
+ *
+ * Source contract (verified at PRD authorship; PRD §13 lock):
+ *   - normalize(s)            — NFC + collapse whitespace + strip commas + trim
+ *   - extractNAPFromHtml(html) — match street/zip/phone from <address> or full body
+ *   - buildNAPTuple(nap)       — join non-null fields with single space
+ *
+ * NEVER duplicate the regexes silently — they MUST stay byte-identical to the
+ * .ts source. If src/utils/extractNAP.ts changes its STREET_RE / ZIP_RE /
+ * PHONE_RE, this shim and the lockstep test must be updated in the same PR.
+ */
+
+'use strict';
+
+/**
+ * @param {string} s
+ * @returns {string}
+ */
+const normalize = (s) =>
+    s.normalize('NFC').replace(/\s+/g, ' ').replace(/,/g, '').trim();
+
+const STREET_RE = /\d+\s+S\s+1st\s+St/i;
+const ZIP_RE = /\b\d{5}\b/;
+const PHONE_RE = /\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}/;
+
+/**
+ * @typedef {{ street: string|null, postalCode: string|null, telephone: string|null }} NAP
+ */
+
+/**
+ * @param {string} haystack
+ * @returns {NAP}
+ */
+function matchNAP(haystack) {
+    return {
+        street: haystack.match(STREET_RE)?.[0] ?? null,
+        postalCode: haystack.match(ZIP_RE)?.[0] ?? null,
+        telephone: haystack.match(PHONE_RE)?.[0] ?? null,
+    };
+}
+
+/**
+ * @param {string} html
+ * @returns {NAP}
+ */
+function extractNAPFromHtml(html) {
+    const addrMatch = html.match(/<address[^>]*>([\s\S]*?)<\/address>/i);
+    const haystack = (addrMatch ? addrMatch[1] : html).replace(/<[^>]+>/g, ' ');
+    return matchNAP(haystack);
+}
+
+/**
+ * @param {NAP} nap
+ * @returns {string}
+ */
+function buildNAPTuple(nap) {
+    return [nap.street, nap.postalCode, nap.telephone]
+        .filter((s) => Boolean(s))
+        .join(' ');
+}
+
+module.exports = { normalize, extractNAPFromHtml, buildNAPTuple };

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/lighthouse.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/lighthouse.mjs
@@ -1,0 +1,249 @@
+/**
+ * `lighthouse` subcommand — wraps `@lhci/cli collect` against the live .org page.
+ *
+ * Behavior contract (FR-LH-01..06, AC-9..13, AC-37, NFR-02 / NFR-09):
+ *   - 3-run median by default; `--runs N` overrides (advisory WARN if N < 3).
+ *   - First run with no baseline → write
+ *     `OpenDoorWebsiteApp/scripts/seo-monitor/.cache/lighthouse-baseline.json`
+ *     with seven fields (seo, accessibility, performance, lhci_version,
+ *     node_version, os, utc).
+ *   - A11y < 90 → exit 1 (FR-LH-03; NFR-02 hard floor).
+ *   - SEO/Perf below baseline (band ±2 per Daniel §1.2) → WARN line, exit
+ *     UNCHANGED (informational only).
+ *   - lhci binary missing (ENOENT / non-zero CLI bootstrap) → exit 2 with
+ *     `LHCI_BINARY_MISSING` diagnostic.
+ *   - Chromium not discovered (Fedora gap; NFR-09) → exit 2 with diagnostic
+ *     naming `CHROME_PATH=/usr/bin/chromium-browser` (or equivalent).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+import os from 'node:os';
+
+import { EXIT_PASS, EXIT_FAIL, EXIT_ERROR } from './exitCodes.mjs';
+import { openBlock, closeBlock, pass, fail, warn, info, error } from './output.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SUBCMD = 'lighthouse';
+
+const DEFAULT_TARGET = 'https://opendoorph.org/';
+const DEFAULT_RUNS = 3;
+const A11Y_FLOOR = 90;
+const REGRESSION_BAND = 2; // Daniel §1.2 ±2 tolerance
+
+const CACHE_DIR = resolve(HERE, '..', '.cache');
+const DEFAULT_BASELINE_PATH = join(CACHE_DIR, 'lighthouse-baseline.json');
+
+/**
+ * @param {{ flags: Record<string, string|boolean>, argv: string[] }} ctx
+ * @param {{ runLhci?: (target: string, runs: number, outDir: string) => Array<{seo:number,a11y:number,perf:number,lhciVersion:string}> }} [deps]
+ * @returns {Promise<number>}
+ */
+export async function runLighthouse(ctx, deps = {}) {
+    const c = openBlock(SUBCMD, ctx.argv);
+    const target = /** @type {string} */ (ctx.flags['--target-url']) || DEFAULT_TARGET;
+    const runs = parseInt(/** @type {string} */ (ctx.flags['--runs']) || `${DEFAULT_RUNS}`, 10);
+    const baselinePath = /** @type {string} */ (ctx.flags['--baseline-from']) || DEFAULT_BASELINE_PATH;
+    const forceRewrite = ctx.flags['--baseline-write'] === true;
+
+    if (runs < DEFAULT_RUNS) {
+        warn(SUBCMD, `runs=${runs} (PRD pins ${DEFAULT_RUNS})`, c);
+    }
+
+    info(SUBCMD, `${runs} collections, mobile, simulated throttling, cold cache, target=${target}`);
+
+    const runLhci = deps.runLhci || defaultRunLhci;
+
+    /** @type {Array<{seo:number, a11y:number, perf:number, lhciVersion:string}>} */
+    let collections;
+    try {
+        if (!existsSync(CACHE_DIR)) mkdirSync(CACHE_DIR, { recursive: true });
+        collections = runLhci(target, runs, CACHE_DIR);
+    } catch (e) {
+        const cls = classifyLhciError(e);
+        if (cls.kind === 'BINARY_MISSING') {
+            error(SUBCMD, `LHCI_BINARY_MISSING — run \`cd OpenDoorWebsiteApp && npm install\``, c);
+        } else if (cls.kind === 'CHROME_MISSING') {
+            error(
+                SUBCMD,
+                `chromium binary not discovered. Set CHROME_PATH=/usr/bin/chromium-browser (or equivalent) and re-run. See OpenDoorWebsiteApp/scripts/seo-monitor/README.md "Fedora notes".`,
+                c,
+            );
+        } else if (cls.kind === 'TRANSPORT') {
+            error(SUBCMD, `TRANSPORT_ERROR ${target} cause=${cls.detail}`, c);
+        } else {
+            error(SUBCMD, `unexpected lhci failure cause=${cls.detail}`, c);
+        }
+        closeBlock(SUBCMD, EXIT_ERROR, c);
+        return EXIT_ERROR;
+    }
+
+    if (!collections.length) {
+        error(SUBCMD, 'lhci returned zero collection results', c);
+        closeBlock(SUBCMD, EXIT_ERROR, c);
+        return EXIT_ERROR;
+    }
+
+    const a11y = median(collections.map((r) => r.a11y));
+    const seo = median(collections.map((r) => r.seo));
+    const perf = median(collections.map((r) => r.perf));
+    const lhciVersion = collections[0].lhciVersion;
+
+    /** @type {{seo:number|null, a11y:number|null, perf:number|null}|null} */
+    const baselineFile = (existsSync(baselinePath) && !forceRewrite) ? readBaseline(baselinePath) : null;
+
+    let exitCode = EXIT_PASS;
+
+    if (a11y >= A11Y_FLOOR) {
+        pass(SUBCMD, `A11y median=${a11y} floor=${A11Y_FLOOR}`, c);
+    } else {
+        fail(SUBCMD, `A11y median=${a11y} floor=${A11Y_FLOOR} delta=${a11y - A11Y_FLOOR}`, c);
+        exitCode = EXIT_FAIL;
+    }
+
+    // SEO / Perf reporting + regression band.
+    if (baselineFile === null || forceRewrite) {
+        info(SUBCMD, `SEO median=${seo} (no baseline; writing first baseline)`);
+        info(SUBCMD, `Performance median=${perf} (no baseline; writing first baseline)`);
+        const written = writeBaseline(baselinePath, { seo, a11y, perf, lhciVersion });
+        info(
+            SUBCMD,
+            `${forceRewrite ? 'BASELINE_REWRITE' : 'BASELINE_WRITTEN'} path=${written}`,
+        );
+    } else {
+        const seoDelta = seo - (baselineFile.seo ?? seo);
+        const perfDelta = perf - (baselineFile.perf ?? perf);
+        if (baselineFile.seo !== null && seoDelta < -REGRESSION_BAND) {
+            warn(
+                SUBCMD,
+                `SEO regression baseline=${baselineFile.seo} current=${seo} delta=${seoDelta} (informational; no exit change)`,
+                c,
+            );
+        } else {
+            info(SUBCMD, `SEO median=${seo} baseline=${baselineFile.seo} delta=${seoDelta >= 0 ? '+' : ''}${seoDelta}`);
+        }
+        if (baselineFile.perf !== null && perfDelta < -REGRESSION_BAND) {
+            warn(
+                SUBCMD,
+                `Performance regression baseline=${baselineFile.perf} current=${perf} delta=${perfDelta} (informational; no exit change)`,
+                c,
+            );
+        } else {
+            info(SUBCMD, `Performance median=${perf} baseline=${baselineFile.perf} delta=${perfDelta >= 0 ? '+' : ''}${perfDelta}`);
+        }
+    }
+
+    c.extra = `a11y=${a11y} seo=${seo} perf=${perf}`;
+    closeBlock(SUBCMD, exitCode, c);
+    return exitCode;
+}
+
+/**
+ * @param {string} target
+ * @param {number} runs
+ * @param {string} outDir
+ * @returns {Array<{seo:number,a11y:number,perf:number,lhciVersion:string}>}
+ */
+function defaultRunLhci(target, runs, outDir) {
+    // Use the project-local lhci binary; works whether invoked from project root or app dir.
+    const lhciBin = resolve(HERE, '..', '..', '..', 'node_modules', '.bin', 'lhci');
+    const args = [
+        'collect',
+        `--url=${target}`,
+        `--numberOfRuns=${runs}`,
+    ];
+    // Run lhci; stdout/stderr inherited so we see progress in CI logs.
+    execFileSync(lhciBin, args, {
+        stdio: ['ignore', 'inherit', 'pipe'],
+        encoding: 'utf8',
+        env: { ...process.env },
+    });
+
+    // Discover the JSON reports lhci wrote. Prefer slice cache, then fall back
+    // to the project-root .lighthouseci/ default.
+    /** @type {string[]} */
+    const candidates = [];
+    const projectLhciDir = resolve(HERE, '..', '..', '..', '.lighthouseci');
+    for (const d of [projectLhciDir, outDir]) {
+        if (!existsSync(d)) continue;
+        for (const name of readdirSync(d)) {
+            if (name.startsWith('lhr-') && name.endsWith('.json')) {
+                candidates.push(join(d, name));
+            }
+        }
+    }
+    if (candidates.length === 0) {
+        throw new Error('lhci produced no lhr-*.json reports');
+    }
+    candidates.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+    const recent = candidates.slice(0, runs);
+
+    /** @type {Array<{seo:number,a11y:number,perf:number,lhciVersion:string}>} */
+    const results = [];
+    for (const path of recent) {
+        const json = JSON.parse(readFileSync(path, 'utf8'));
+        results.push({
+            seo: Math.round((json.categories?.seo?.score ?? 0) * 100),
+            a11y: Math.round((json.categories?.accessibility?.score ?? 0) * 100),
+            perf: Math.round((json.categories?.performance?.score ?? 0) * 100),
+            lhciVersion: json.lighthouseVersion || 'unknown',
+        });
+    }
+    return results;
+}
+
+function classifyLhciError(e) {
+    const msg = String((e && e.message) || e || '');
+    if (e && e.code === 'ENOENT') {
+        return { kind: 'BINARY_MISSING', detail: 'ENOENT' };
+    }
+    if (/CHROME_PATH/i.test(msg) || /chrome-launcher/i.test(msg) || /No Chrome installations/i.test(msg) || /must be set to a Chrome/i.test(msg)) {
+        return { kind: 'CHROME_MISSING', detail: 'chromium not discovered' };
+    }
+    if (/ECONNREFUSED/i.test(msg) || /ENOTFOUND/i.test(msg) || /timed out/i.test(msg)) {
+        return { kind: 'TRANSPORT', detail: msg.split('\n')[0].slice(0, 120) };
+    }
+    return { kind: 'UNKNOWN', detail: msg.split('\n')[0].slice(0, 120) };
+}
+
+function median(nums) {
+    const sorted = [...nums].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    if (sorted.length % 2 === 0) {
+        return Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+    }
+    return sorted[mid];
+}
+
+function readBaseline(path) {
+    try {
+        const obj = JSON.parse(readFileSync(path, 'utf8'));
+        return {
+            seo: obj.seo ?? null,
+            a11y: obj.a11y ?? obj.accessibility ?? null,
+            perf: obj.perf ?? obj.performance ?? null,
+        };
+    } catch {
+        return { seo: null, a11y: null, perf: null };
+    }
+}
+
+function writeBaseline(path, vals) {
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const body = {
+        seo: vals.seo,
+        accessibility: vals.a11y,
+        performance: vals.perf,
+        lhci_version: vals.lhciVersion,
+        node_version: process.version,
+        os: `${os.platform()} ${os.release()}`,
+        utc: new Date().toISOString(),
+    };
+    writeFileSync(path, JSON.stringify(body, null, 2) + '\n', 'utf8');
+    return path;
+}
+
+export const subcommandName = SUBCMD;

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/output.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/output.mjs
@@ -1,0 +1,88 @@
+/**
+ * Output helpers — produce the cli-ux-spec.md §3 / §3.5 devlog block shape.
+ *
+ * Stable strings (per cli-ux-spec.md §10 glossary) — DO NOT alter casually:
+ *   - `=== seo-monitor <subcmd> ===`
+ *   - `UTC: <ISO-8601-Z>`
+ *   - `COMMAND: <full command>`
+ *   - `<MARKER> <subcmd>: <human sentence> [key=value ...]`
+ *   - `SUMMARY <subcmd> exit=<N> pass=<N> fail=<N> warn=<N> error=<N>`
+ *   - `EXIT: <N>`
+ *
+ * Markers (cli-ux-spec.md §3.2): PASS, FAIL, WARN, INFO, ERROR, DEBUG.
+ * No emoji, no Unicode glyphs, no color-only signals. ASCII tokens carry
+ * meaning so the output is screen-reader-friendly and grep-stable.
+ */
+
+/** @typedef {{pass:number, fail:number, warn:number, error:number, extra?:string}} Counters */
+
+/**
+ * Open a subcommand devlog block. Prints header + UTC + COMMAND lines.
+ *
+ * @param {string} subcmd
+ * @param {string[]} argv  Argv for the COMMAND echo line.
+ * @returns {Counters}     Counters object the caller mutates as PASS/FAIL/WARN/ERROR lines fire.
+ */
+export function openBlock(subcmd, argv) {
+    process.stdout.write(`=== seo-monitor ${subcmd} ===\n`);
+    process.stdout.write(`UTC: ${new Date().toISOString()}\n`);
+    process.stdout.write(`COMMAND: ${argv.join(' ')}\n`);
+    return { pass: 0, fail: 0, warn: 0, error: 0 };
+}
+
+/**
+ * Close a subcommand devlog block. Prints SUMMARY + EXIT lines.
+ *
+ * @param {string} subcmd
+ * @param {number} exitCode
+ * @param {Counters} c
+ */
+export function closeBlock(subcmd, exitCode, c) {
+    const extra = c.extra ? ` ${c.extra}` : '';
+    process.stdout.write(
+        `SUMMARY ${subcmd} exit=${exitCode} pass=${c.pass} fail=${c.fail} warn=${c.warn} error=${c.error}${extra}\n`,
+    );
+    process.stdout.write(`EXIT: ${exitCode}\n`);
+}
+
+/** @param {string} subcmd @param {string} msg @param {Counters} c */
+export function pass(subcmd, msg, c) {
+    process.stdout.write(`PASS ${subcmd}: ${msg}\n`);
+    c.pass += 1;
+}
+
+/** @param {string} subcmd @param {string} msg @param {Counters} c */
+export function fail(subcmd, msg, c) {
+    process.stdout.write(`FAIL ${subcmd}: ${msg}\n`);
+    c.fail += 1;
+}
+
+/** @param {string} subcmd @param {string} msg @param {Counters} c */
+export function warn(subcmd, msg, c) {
+    process.stdout.write(`WARN ${subcmd}: ${msg}\n`);
+    c.warn += 1;
+}
+
+/** @param {string} subcmd @param {string} msg @param {Counters} [c] */
+export function info(subcmd, msg, c) {
+    process.stdout.write(`INFO ${subcmd}: ${msg}\n`);
+    // INFO does not contribute to any counter.
+    void c;
+}
+
+/** @param {string} subcmd @param {string} msg @param {Counters} c */
+export function error(subcmd, msg, c) {
+    process.stdout.write(`ERROR ${subcmd}: ${msg}\n`);
+    c.error += 1;
+}
+
+/** @param {string} subcmd @param {string} msg @param {Counters} [c] */
+export function debug(subcmd, msg, c) {
+    process.stdout.write(`DEBUG ${subcmd}: ${msg}\n`);
+    void c;
+}
+
+/** Plain stdout line (no marker prefix). For URLs, MILESTONE_DAY=, etc. */
+export function raw(line) {
+    process.stdout.write(`${line}\n`);
+}

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/rankDue.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/rankDue.mjs
@@ -1,0 +1,128 @@
+/**
+ * `rank-due` subcommand — Slice C foundation milestone signaller.
+ *
+ * Behavior contract (FR-RANK-01..07; AC-15..18, AC-38):
+ *   - Reads `baseline_date` from config; `--baseline-date YYYY-MM-DD` overrides.
+ *   - Computes days-since-baseline using America/Chicago local civil-date on
+ *     BOTH endpoints (NEVER bare new Date() per AC-38).
+ *   - On day 30/60/90: emit milestone banner + four runbook 5.4 queries +
+ *     `MILESTONE_DAY=<N>` as the LAST line of stdout.
+ *   - On non-milestone day: silent (or DEBUG with --verbose); LAST line is
+ *     `MILESTONE_DAY=none`.
+ *   - On empty / future / malformed config: emit info/warn line, LAST line is
+ *     `MILESTONE_DAY=none`. NEVER fails exit (FR-RANK-07).
+ *   - The `--today YYYY-MM-DD` flag is a TEST-only override for the "today"
+ *     anchor (used by AC-16 / AC-38 unit tests). Hidden from --help.
+ *
+ * The structured marker regex (cli-ux-spec.md §10 glossary; locked verbatim):
+ *   ^MILESTONE_DAY=(30|60|90|none)$
+ */
+
+import { EXIT_PASS } from './exitCodes.mjs';
+import { openBlock, closeBlock, info, warn, debug, raw } from './output.mjs';
+import { loadConfig, DEFAULT_CONFIG_PATH } from './config.mjs';
+import { chicagoCivilDate, daysSinceBaseline, civilDateToUtcNoon } from './datetime.mjs';
+
+const SUBCMD = 'rank-due';
+
+const RUNBOOK_QUERIES = [
+    'church pleasant hill mo',
+    'full gospel church pleasant hill',
+    'pentecostal church pleasant hill mo',
+    'open door full gospel church',
+];
+
+/**
+ * Stable last-line marker regex shape. Documented byte-for-byte in
+ * cli-ux-spec.md §10 glossary, the README §"Output format", and this file.
+ *
+ * Matches: MILESTONE_DAY=30 | =60 | =90 | =none
+ */
+export const MILESTONE_MARKER_REGEX = /^MILESTONE_DAY=(30|60|90|none)$/;
+
+const MILESTONE_DAYS = new Set([30, 60, 90]);
+
+/**
+ * @param {{ flags: Record<string, string|boolean>, argv: string[] }} ctx
+ * @param {{ now?: () => Date, configPath?: string }} [deps]
+ * @returns {number}
+ */
+export function runRankDue(ctx, deps = {}) {
+    const c = openBlock(SUBCMD, ctx.argv);
+
+    let config;
+    try {
+        config = loadConfig(deps.configPath || DEFAULT_CONFIG_PATH);
+    } catch (e) {
+        // Malformed JSON — treat as empty per FR-RANK-07.
+        warn(SUBCMD, `config.json malformed (cause=${(e && e.message) || e}); treating as empty.`, c);
+        return finishWithMarker(c, 'none');
+    }
+
+    const flagDate = /** @type {string|undefined} */ (ctx.flags['--baseline-date']) || undefined;
+    const baselineDate = (flagDate || config.baseline_date || '').trim();
+
+    if (!baselineDate) {
+        info(SUBCMD, 'not yet armed; populate config.json from runbook 5.1 (set baseline_date to your GBP verification date).');
+        return finishWithMarker(c, 'none');
+    }
+
+    let baselineYmd;
+    try {
+        // Validate the YYYY-MM-DD shape via civilDateToUtcNoon.
+        civilDateToUtcNoon(baselineDate);
+        baselineYmd = baselineDate;
+    } catch (e) {
+        warn(SUBCMD, `baseline_date invalid (cause=${(e && e.message) || e}); treating as empty.`, c);
+        return finishWithMarker(c, 'none');
+    }
+
+    const now = deps.now ? deps.now() : new Date();
+    const todayYmd = /** @type {string|undefined} */ (ctx.flags['--today']) || chicagoCivilDate(now);
+
+    let days;
+    try {
+        days = daysSinceBaseline(baselineYmd, todayYmd);
+    } catch (e) {
+        warn(SUBCMD, `today derivation failed (cause=${(e && e.message) || e}); treating as empty.`, c);
+        return finishWithMarker(c, 'none');
+    }
+
+    if (days < 0) {
+        info(SUBCMD, `baseline is in the future; will arm at ${baselineYmd}.`);
+        return finishWithMarker(c, 'none');
+    }
+
+    if (MILESTONE_DAYS.has(days)) {
+        info(SUBCMD, `today=${todayYmd} (America/Chicago) baseline=${baselineYmd} days_since=${days} milestone=${days}`);
+        info(SUBCMD, 'run the four queries in runbook 5.4 and capture rank in the devlog:');
+        for (let i = 0; i < RUNBOOK_QUERIES.length; i += 1) {
+            info(SUBCMD, `  ${i + 1}. ${RUNBOOK_QUERIES[i]}`);
+        }
+        return finishWithMarker(c, String(days), { milestoneDay: days });
+    }
+
+    if (ctx.flags['--verbose'] === true) {
+        debug(SUBCMD, `non-milestone day, days-since-baseline=${days}`);
+    }
+    return finishWithMarker(c, 'none');
+}
+
+/**
+ * Close the block then emit the trailing MILESTONE_DAY= marker as the
+ * absolute last line. Always returns EXIT_PASS (FR-RANK-07).
+ *
+ * @param {{pass:number,fail:number,warn:number,error:number,extra?:string}} c
+ * @param {'30'|'60'|'90'|'none'} marker
+ * @param {{ milestoneDay?: number }} [opts]
+ * @returns {number}
+ */
+function finishWithMarker(c, marker, opts = {}) {
+    c.extra = `milestone_day=${opts.milestoneDay ?? 'none'}`;
+    closeBlock(SUBCMD, EXIT_PASS, c);
+    raw(`MILESTONE_DAY=${marker}`);
+    return EXIT_PASS;
+}
+
+export const subcommandName = SUBCMD;
+export const RUNBOOK_5_4_QUERIES = RUNBOOK_QUERIES;

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/richResults.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/richResults.mjs
@@ -1,0 +1,29 @@
+/**
+ * `rich-results` subcommand — print the pre-filled Google Rich Results URL.
+ *
+ * Always exits 0 (FR-RR-02). Never makes a network call (per Solomon's
+ * "rich-results non-call is wisdom" commendation; the failure mode is moved
+ * off the utility's surface). No `fetch`, no `https.request`, no
+ * `child_process` — verified by the unit test (T-I-07 `rich-results-no-network`).
+ */
+
+import { EXIT_PASS } from './exitCodes.mjs';
+import { openBlock, closeBlock, info, raw } from './output.mjs';
+
+const SUBCMD = 'rich-results';
+const RICH_RESULTS_URL = 'https://search.google.com/test/rich-results?url=https%3A%2F%2Fopendoorph.org%2F';
+
+/**
+ * @param {{ argv: string[] }} ctx
+ * @returns {number}
+ */
+export function runRichResults(ctx) {
+    const c = openBlock(SUBCMD, ctx.argv);
+    info(SUBCMD, 'open the URL below in a browser; capture the LocalBusiness eligibility verdict in your devlog.');
+    raw(RICH_RESULTS_URL);
+    closeBlock(SUBCMD, EXIT_PASS, c);
+    return EXIT_PASS;
+}
+
+export const subcommandName = SUBCMD;
+export const RICH_RESULTS_TEST_URL = RICH_RESULTS_URL;

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/lib/schema.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/lib/schema.mjs
@@ -1,0 +1,265 @@
+/**
+ * `schema` subcommand — JSON-LD validation against served .org HTML
+ * (FR-SCHEMA-01..07). Mirrors slice-A FR-01..FR-04 invariants byte-for-byte.
+ *
+ * REUSES: `extractNAPShim.cjs` (D-5 shim re-exporting normalize +
+ * extractNAPFromHtml + buildNAPTuple from src/utils/extractNAP.ts). The
+ * lockstep test (`extract-nap-shim.test.mjs`) asserts shim-vs-source
+ * byte-equality on the slice-A `napByteMatch.test.ts` fixture pattern.
+ *
+ * Address-side scope: per DEC-2026-05-03-003, the HARD assertion is on the
+ * `streetAddress + postalCode + telephone (if present)` tuple only;
+ * `addressLocality`, `addressRegion`, `name` are advisory WARN-only.
+ */
+
+import { createRequire } from 'node:module';
+
+import { EXIT_PASS, EXIT_FAIL, EXIT_ERROR } from './exitCodes.mjs';
+import { openBlock, closeBlock, pass, fail, warn, info, error } from './output.mjs';
+
+const require = createRequire(import.meta.url);
+const { normalize, extractNAPFromHtml, buildNAPTuple } = require('./extractNAPShim.cjs');
+
+const SUBCMD = 'schema';
+const DEFAULT_TARGET = 'https://opendoorph.org/';
+const FACEBOOK_URL = 'https://www.facebook.com/profile.php?id=100064858415448';
+const DEFAULT_TIMEOUT_S = 10;
+
+/**
+ * @param {{ flags: Record<string, string|boolean>, argv: string[] }} ctx
+ * @param {{ fetchHtml?: (url: string, timeoutSec: number) => Promise<string> }} [deps]
+ * @returns {Promise<number>}
+ */
+export async function runSchema(ctx, deps = {}) {
+    const c = openBlock(SUBCMD, ctx.argv);
+    const url = /** @type {string} */ (ctx.flags['--target-url']) || DEFAULT_TARGET;
+    const timeoutSec = parseInt(/** @type {string} */ (ctx.flags['--timeout-seconds']) || `${DEFAULT_TIMEOUT_S}`, 10);
+    const fetchHtml = deps.fetchHtml || defaultFetchHtml;
+
+    info(SUBCMD, `fetching ${url}`);
+
+    let html;
+    try {
+        html = await fetchHtml(url, timeoutSec);
+    } catch (e) {
+        const cause = String((e && e.message) || e || 'unknown');
+        error(SUBCMD, `${url} unreachable cause=${cause}`, c);
+        closeBlock(SUBCMD, EXIT_ERROR, c);
+        return EXIT_ERROR;
+    }
+
+    /** @type {number} */
+    let exitCode = EXIT_PASS;
+
+    // FR-SCHEMA-01 — exactly one application/ld+json block.
+    const blocks = extractJsonLdBlocks(html);
+    if (blocks.length !== 1) {
+        fail(SUBCMD, `ld+json blocks expected=1 got=${blocks.length}`, c);
+        exitCode = EXIT_FAIL;
+        closeBlock(SUBCMD, exitCode, c);
+        return exitCode;
+    }
+    pass(SUBCMD, 'ld+json blocks count=1', c);
+
+    /** @type {any} */
+    let parsed;
+    try {
+        parsed = JSON.parse(blocks[0]);
+    } catch (e) {
+        fail(SUBCMD, `ld+json parse failed cause=${(e && e.message) || e}`, c);
+        closeBlock(SUBCMD, EXIT_FAIL, c);
+        return EXIT_FAIL;
+    }
+
+    // FR-SCHEMA-02 — @context byte-exact, @type includes Church.
+    if (parsed['@context'] === 'https://schema.org') {
+        pass(SUBCMD, '@context value=https://schema.org', c);
+    } else {
+        fail(SUBCMD, `@context expected=https://schema.org got=${JSON.stringify(parsed['@context'])}`, c);
+        exitCode = EXIT_FAIL;
+    }
+
+    const t = parsed['@type'];
+    const typeIncludesChurch = t === 'Church' || (Array.isArray(t) && t.includes('Church'));
+    if (typeIncludesChurch) {
+        pass(SUBCMD, `@type includes=Church value=${JSON.stringify(t)}`, c);
+    } else {
+        fail(SUBCMD, `@type expected to include Church got=${JSON.stringify(t)}`, c);
+        exitCode = EXIT_FAIL;
+    }
+
+    // FR-SCHEMA-03 — url byte-exact.
+    if (parsed.url === DEFAULT_TARGET) {
+        pass(SUBCMD, `url byte-equal=${DEFAULT_TARGET}`, c);
+    } else {
+        fail(SUBCMD, `url expected=${DEFAULT_TARGET} got=${JSON.stringify(parsed.url)}`, c);
+        exitCode = EXIT_FAIL;
+    }
+
+    // FR-SCHEMA-04 — exactly one <link rel="canonical"> with byte-equal href.
+    const canonicalLinks = extractCanonicalLinks(html);
+    if (canonicalLinks.length === 1 && canonicalLinks[0] === DEFAULT_TARGET) {
+        pass(SUBCMD, `link rel=canonical href byte-equal=${DEFAULT_TARGET}`, c);
+    } else {
+        fail(
+            SUBCMD,
+            `link rel=canonical count=${canonicalLinks.length} hrefs=${JSON.stringify(canonicalLinks)} expected=[${DEFAULT_TARGET}]`,
+            c,
+        );
+        exitCode = EXIT_FAIL;
+    }
+
+    // FR-SCHEMA-05 — sameAs.length === 1 + Facebook URL byte-equal.
+    const sameAs = parsed.sameAs;
+    if (Array.isArray(sameAs) && sameAs.length === 1 && sameAs[0] === FACEBOOK_URL) {
+        pass(SUBCMD, `sameAs length=1 sole=${FACEBOOK_URL}`, c);
+    } else {
+        const got = Array.isArray(sameAs) ? sameAs.length : 0;
+        const first = Array.isArray(sameAs) && sameAs.length > 0 ? sameAs[0] : '(none)';
+        fail(SUBCMD, `sameAs length expected=1 got=${got} first=${first}`, c);
+        exitCode = EXIT_FAIL;
+    }
+
+    // FR-SCHEMA-06 — NAP byte-equality (REUSE extractNAP shim).
+    // If the live HTML has no rendered <address> element (the production
+    // build is a SPA whose address is rendered client-side by React),
+    // we cannot derive the rendered tuple from the served bytes. In that
+    // case the byte-comparison is skipped with a WARN advisory; the slice-A
+    // napByteMatch.test.ts covers the build-time invariant on the JSDOM
+    // side. Per DEC-2026-05-03-003: address+phone scope only; locality and
+    // region drift are ALWAYS WARN-only.
+    const napHard = compareNapHard(html, parsed);
+    if (napHard.skipped) {
+        warn(SUBCMD, napHard.message, c);
+    } else if (napHard.ok) {
+        pass(SUBCMD, 'NAP byte-equal scope=address+phone (DEC-2026-05-03-003)', c);
+    } else {
+        fail(SUBCMD, napHard.message, c);
+        exitCode = EXIT_FAIL;
+    }
+
+    // Advisory drift — locality/region/name. Never failing exit.
+    const advisories = collectAdvisories(html, parsed);
+    for (const adv of advisories) {
+        warn(SUBCMD, adv, c);
+    }
+
+    closeBlock(SUBCMD, exitCode, c);
+    return exitCode;
+}
+
+/**
+ * Default HTTP fetch via Node 18+ built-in fetch.
+ *
+ * @param {string} url
+ * @param {number} timeoutSec
+ * @returns {Promise<string>}
+ */
+async function defaultFetchHtml(url, timeoutSec) {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), timeoutSec * 1000);
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) {
+            throw new Error(`HTTP ${res.status}`);
+        }
+        return await res.text();
+    } finally {
+        clearTimeout(t);
+    }
+}
+
+/**
+ * Extract the inner text of every <script type="application/ld+json"> block
+ * from a raw HTML string. Returns a list (length 0, 1, or many).
+ *
+ * @param {string} html
+ * @returns {string[]}
+ */
+export function extractJsonLdBlocks(html) {
+    const re = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+    const out = [];
+    let m;
+    while ((m = re.exec(html)) !== null) {
+        out.push(m[1].trim());
+    }
+    return out;
+}
+
+/**
+ * Extract every <link rel="canonical"> href value (byte-as-written; no URL
+ * normalization).
+ *
+ * @param {string} html
+ * @returns {string[]}
+ */
+export function extractCanonicalLinks(html) {
+    const re = /<link\b[^>]*\brel=["']canonical["'][^>]*\bhref=["']([^"']+)["'][^>]*>/gi;
+    const out = [];
+    let m;
+    while ((m = re.exec(html)) !== null) {
+        out.push(m[1]);
+    }
+    // Also handle href-before-rel attribute order.
+    const re2 = /<link\b[^>]*\bhref=["']([^"']+)["'][^>]*\brel=["']canonical["'][^>]*>/gi;
+    while ((m = re2.exec(html)) !== null) {
+        if (!out.includes(m[1])) out.push(m[1]);
+    }
+    return out;
+}
+
+function compareNapHard(html, parsed) {
+    const hasAddressEl = /<address\b[^>]*>/i.test(html);
+    if (!hasAddressEl) {
+        return {
+            skipped: true,
+            message: 'NAP byte-equal skipped: no <address> element in served HTML (SPA renders client-side; slice-A napByteMatch.test.ts covers the build-time invariant)',
+        };
+    }
+    const rendered = extractNAPFromHtml(html);
+    const renderedTuple = buildNAPTuple(rendered);
+
+    const addr = (parsed && parsed.address) || {};
+    const schemaSide = {
+        street: addr.streetAddress ? normalize(String(addr.streetAddress)) : null,
+        postalCode: addr.postalCode ? normalize(String(addr.postalCode)) : null,
+        telephone: parsed.telephone ? normalize(String(parsed.telephone)) : null,
+    };
+    const schemaTuple = buildNAPTuple(schemaSide);
+
+    if (renderedTuple === schemaTuple) {
+        return { ok: true, message: '' };
+    }
+    return {
+        ok: false,
+        message: `NAP tuple mismatch schema="${schemaTuple}" rendered="${renderedTuple}"`,
+    };
+}
+
+function collectAdvisories(html, parsed) {
+    const out = [];
+    const renderedText = html.replace(/<[^>]+>/g, ' ');
+    const addr = (parsed && parsed.address) || {};
+
+    if (addr.addressLocality) {
+        const locality = String(addr.addressLocality);
+        if (!renderedText.includes(locality)) {
+            out.push(`addressLocality drift advisory=${locality} not found in rendered HTML (DEC-2026-05-03-003 advisory)`);
+        }
+    }
+    if (addr.addressRegion) {
+        const region = String(addr.addressRegion);
+        if (!renderedText.includes(region)) {
+            out.push(`addressRegion drift advisory=${region} not found in rendered HTML (DEC-2026-05-03-003 advisory)`);
+        }
+    }
+    if (parsed && parsed.name) {
+        const name = String(parsed.name);
+        if (!renderedText.includes(name)) {
+            out.push(`name drift advisory=${name} not found in rendered HTML (DEC-2026-05-03-003 advisory)`);
+        }
+    }
+    return out;
+}
+
+export const subcommandName = SUBCMD;

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.config.json
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.config.json
@@ -1,0 +1,10 @@
+{
+    "baseline_date": null,
+    "lighthouse_baseline": {
+        "seo": null,
+        "accessibility": null,
+        "performance": null,
+        "best_practices": null
+    },
+    "canonical_domain": "opendoorph.org"
+}

--- a/OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.mjs
+++ b/OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * seo-monitor — SEO monitoring + post-merge UAT automation utility.
+ *
+ * Six subcommands plus an `all` umbrella; plain Node JS + JSDoc per NFR-01;
+ * no new runtime deps; one new devDep (@lhci/cli) per FR-PKG-02.
+ *
+ * Entry point dispatcher; each subcommand lives in lib/<name>.mjs.
+ *
+ * Stable strings (per cli-ux-spec.md §10) — DO NOT alter casually:
+ *   - `=== seo-monitor <subcmd> ===`
+ *   - `SUMMARY <subcmd> exit=<N> pass=<N> fail=<N> warn=<N> error=<N>`
+ *   - `EXIT: <N>`
+ *   - `MILESTONE_DAY=(30|60|90|none)` — last line of every rank-due block
+ *
+ * Memory hot-lessons honored:
+ *   - "PH" expands to "Pleasant Hill", never the Southeast-Asian island
+ *     nation a careless reader might assume. (NFR-04, hot-lesson #1.)
+ *   - Tests run locally before push. (Memory feedback_test_before_push.)
+ *   - Curl URL boundary BEFORE running tests. (Lesson 8 of dev memory.)
+ *   - BUG-053-01 — NEW workflow file (.github/workflows/seo-monitor.yml);
+ *     ZERO edits to node-build.yml.
+ *   - Plain Node JS + JSDoc; NO TypeScript, NO tsx/ts-node.
+ *   - Source PRD is the implementation spec. (Render verbatim; do not reframe.)
+ */
+
+import { parseArgs, listSubcommands, suggestSubcommand } from './lib/argv.mjs';
+import { EXIT_PASS, EXIT_ERROR } from './lib/exitCodes.mjs';
+import { runCanonical } from './lib/canonical.mjs';
+import { runSchema } from './lib/schema.mjs';
+import { runLighthouse } from './lib/lighthouse.mjs';
+import { runRichResults } from './lib/richResults.mjs';
+import { runRankDue } from './lib/rankDue.mjs';
+import { runAll } from './lib/all.mjs';
+
+const HELP = `seo-monitor — SEO monitoring + post-merge UAT automation utility.
+
+Usage:
+  node OpenDoorWebsiteApp/scripts/seo-monitor/seo-monitor.mjs <subcommand> [flags]
+
+Subcommands:
+  canonical     Four-domain redirect-chain posture check (curl -sIL).
+  schema        Asserts FR-01..FR-04 schema invariants on the served .org HTML.
+  lighthouse    3-run median Lighthouse SEO + A11y + Perf on /.
+  rich-results  Print pre-filled Google Rich Results Test URL (no network).
+  rank-due      Day-30/60/90 milestone signaller (Slice C foundation).
+  all           Run all five subcommands; bitwise-OR exit of S1..S4.
+
+Global flags:
+  --help            Print this screen and exit 0.
+  --verbose         Emit one extra DEBUG line per check.
+  --no-color        Force ASCII status markers only (no ANSI color sequences).
+
+Subcommand flags:
+  canonical:    --timeout-seconds <int>   (default 10)
+  schema:       --target-url <url>  --timeout-seconds <int>
+  lighthouse:   --baseline-from <path>  --baseline-write  --runs <int>  --target-url <url>
+  rank-due:     --baseline-date <YYYY-MM-DD>
+
+Exit codes:
+  0  pass / informational
+  1  expected-class failure (assertion fired)
+  2  config error / unexpected (transport, USAGE_ERROR, missing binary)
+
+See OpenDoorWebsiteApp/scripts/seo-monitor/README.md for the full reference.
+`;
+
+async function main() {
+    // process.argv = [node, script, ...rest]
+    const rest = process.argv.slice(2);
+    const parsed = parseArgs(rest);
+
+    if (parsed.helpRequested && parsed.subcommand === null && !parsed.error) {
+        process.stdout.write(HELP);
+        return EXIT_PASS;
+    }
+
+    if (parsed.error) {
+        process.stdout.write(`ERROR usage: ${parsed.error}\n`);
+        // Did-you-mean suggestion when the error names an unknown subcommand.
+        const m = /unknown subcommand "([^"]+)"/.exec(parsed.error);
+        if (m) {
+            const suggestion = suggestSubcommand(m[1]);
+            if (suggestion) {
+                process.stdout.write(`ERROR usage: did you mean "${suggestion}"?\n`);
+            }
+            process.stdout.write(`ERROR usage: see --help for the ${listSubcommands().length} recognized subcommands.\n`);
+        }
+        process.stdout.write(HELP);
+        return EXIT_ERROR;
+    }
+
+    if (parsed.subcommand === null) {
+        // No subcommand and no --help → show help, exit 0 (FR-CLI-01 / AC-19).
+        process.stdout.write(HELP);
+        return EXIT_PASS;
+    }
+
+    if (parsed.helpRequested) {
+        // Subcommand-scoped help — for now identical to the root help screen.
+        process.stdout.write(HELP);
+        return EXIT_PASS;
+    }
+
+    const ctx = {
+        flags: parsed.flags,
+        argv: ['node', 'scripts/seo-monitor/seo-monitor.mjs', parsed.subcommand, ...rest.slice(rest.indexOf(parsed.subcommand) + 1)],
+    };
+
+    switch (parsed.subcommand) {
+        case 'canonical':    return await runCanonical(ctx);
+        case 'schema':       return await runSchema(ctx);
+        case 'lighthouse':   return await runLighthouse(ctx);
+        case 'rich-results': return runRichResults(ctx);
+        case 'rank-due':     return runRankDue(ctx);
+        case 'all':          return await runAll(ctx);
+        default: {
+            process.stdout.write(`ERROR usage: subcommand "${parsed.subcommand}" not wired\n`);
+            process.stdout.write(HELP);
+            return EXIT_ERROR;
+        }
+    }
+}
+
+main().then((code) => {
+    process.exit(code);
+}).catch((e) => {
+    process.stdout.write(`ERROR fatal: ${(e && e.stack) || e}\n`);
+    process.exit(EXIT_ERROR);
+});


### PR DESCRIPTION
## Summary

Closes Issue #58 Slice C foundation. Adds a small Node CLI + scheduled GitHub Actions workflow that:

- Replaces the two overdue Slice A USER actions (Demo URL verification 2026-05-06 / Production curl verification 2026-05-05) with automation
- Captures the upcoming-due Lighthouse baseline (2026-05-11) on the first manual `workflow_dispatch` (D-6 Jericho first-march)
- Lays the Slice C 30/60/90-day rank-tracking foundation — emits `MILESTONE_DAY=30|60|90|none` on each tick; the workflow grep fires the Issue #58 reminder on milestone days only
- Activates automatically once the elder commits a `baseline_date` to `seo-monitor.config.json` after Slice B GBP verification

## Files added / modified

- **NEW** `.github/workflows/seo-monitor.yml` (separate workflow; **zero edits to `node-build.yml` or `terraform.yml`** — BUG-053-01 fence held)
- **NEW** `OpenDoorWebsiteApp/scripts/seo-monitor/` — entry + 8 lib/ modules + 9 tests + 6 fixtures + jest.config.cjs + config.json + 246-line README
- **MODIFIED** `OpenDoorWebsiteApp/package.json` — 8 new scripts (7 `seo:*` umbrella + per-subcommand + 1 `test:seo` Jest fallback per Plan-Dev spike PASS-B); 1 new devDep (`@lhci/cli ^0.15.1`)
- **MODIFIED** `OpenDoorWebsiteApp/.gitignore` — adds `scripts/seo-monitor/.cache/`, `.lighthouseci/`, `seo-check.out`
- **MODIFIED** `OpenDoorWebsiteApp/README.md` — cross-link to utility README

## Live results from Bezalel's spikes

```text
$ npm run test:seo
Test Suites: 9 passed, 9 total
Tests:       62 passed, 62 total
Time:        0.687 s

$ CHROME_PATH=$(...) npx lhci collect --url=https://opendoorph.org/ --numberOfRuns=1
SEO=92  A11y=96 (above NFR-02 floor of 90)  Perf=99  BP=96
```

Both Plan-Dev handoff spikes resolved as PASS-B:
- Spike 1.1: CRA refuses `.mjs` outside `src/` → added `test:seo` (8th script, non-`seo:*` namespace, preserves the seven-`seo:*` invariant) + `jest.config.cjs`
- Spike 1.2: Fedora 43 needs `CHROME_PATH=/var/home/meconnelly/.cache/ms-playwright/chromium-1217/chrome-linux64/chrome`

## BUG-053-01 attestation

```bash
$ git diff master -- .github/workflows/node-build.yml
(empty)
$ git diff master -- .github/workflows/terraform.yml
(empty)
$ git status --short .github/workflows/
?? .github/workflows/seo-monitor.yml
```

## Constraints honored

- One new devDep only (`@lhci/cli`); zero new runtime deps
- Plain Node JS + JSDoc (NFR-01); no TypeScript / no `tsx`/`ts-node`
- No auth tokens; default `GITHUB_TOKEN` only (`permissions: { contents: read, issues: write }` at workflow level)
- No "Philippines" text anywhere except the documented test-filename exception (`no-philippines.test.mjs` excludes its own filename from its scan)
- BUG-053-01: NEW workflow file, NOT an edit to `node-build.yml`

## Test plan

- [x] `cd OpenDoorWebsiteApp && npm install` (one new devDep)
- [x] `cd OpenDoorWebsiteApp && npm run test:seo` → 62/62 GREEN
- [x] `cd OpenDoorWebsiteApp && CHROME_PATH=... node scripts/seo-monitor/seo-monitor.mjs all` → live run on opendoorph.org
- [x] `git diff master -- .github/workflows/node-build.yml` → empty
- [x] `git diff master -- .github/workflows/terraform.yml` → empty
- [ ] **POST-MERGE: Jericho first-march** — `gh workflow run seo-monitor.yml -R P47Phoenix/OpenDoorPH-website` then `gh run watch`; confirm Issue #58 closure-confirmation comment posted with merge SHA

## Implementation deviations (documented)

- **canonical**: extended to honor FR-CANON-01 posture (b) — sister domains return 200 + `<link rel=canonical>` to .org, no edge redirect (caught at Step 7 stdout verification per Lesson 8)
- **schema**: NAP byte-comparison gracefully WARN-skips when `<address>` absent in served HTML (SPA-rendered; build-time `napByteMatch.test.ts` continues to cover the JSDOM invariant)

## Known issues (with remediation timelines)

- AC-33 + AC-35 grep coverage extension to `no-philippines.test.mjs` — target 2026-05-15
- R-2: Lighthouse baseline JSON write/read cycle unit test — defer to next slice (Q3 2026)
- Solomon's 3 follow-ups (shared forbidden-token guard helper; `cancel-in-progress: false` ADR; schema NAP-skip re-evaluation when SSR/pre-rendering lands)
- test-strategy §10 row 2 stale `ci-activation-plan.md` reference — cosmetic typo, target 2026-05-15

## Pipeline references

- Run: `run-2026-05-09-seo1` (FEATURE; 6 stages active, Stage 4 SKIPPED per single-module rule)
- All 4 Stage 7 UAT DoD validators returned DONE (Thomas DONE-WITH-WARN — non-blocking AC-33/AC-35 grep gap)
- Release plan: `.delivery/artifacts/07-uat/devops/release-plan.md`
- Release notes: `.delivery/artifacts/07-uat/tech-writer/release-notes.md`
- User guide: `.delivery/artifacts/07-uat/tech-writer/user-guide.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)