### PR TITLE
fix(deps): override tmp@^0.2.4 to unblock Dependabot security update (closes #72)

### DIFF
--- a/OpenDoorWebsiteApp/package-lock.json
+++ b/OpenDoorWebsiteApp/package-lock.json
@@ -8705,19 +8705,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -13029,16 +13016,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -17636,30 +17613,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/OpenDoorWebsiteApp/package.json
+++ b/OpenDoorWebsiteApp/package.json
@@ -92,6 +92,7 @@
     "svgo@>=2.1.0 <2.8.1": "2.8.2",
     "underscore@<=1.13.7": "1.13.8",
     "serialize-javascript": "7.0.5",
-    "@tootallnate/once": "3.0.1"
+    "@tootallnate/once": "3.0.1",
+    "tmp": "^0.2.4"
   }
 }


### PR DESCRIPTION
## Summary

PR #71 introduced a regression: Dependabot's `tmp` security update has been failing on every push to master since 2026-05-10 02:24 UTC. This fix adds an `overrides` entry to force `tmp` to a patched version.

**Caught by:** elder via `#checkin-build-deploy` Slack channel (CI failure ping post-merge). The team's UAT regression battery in run-2026-05-09-seo1 should have caught this — saved as `feedback_regression_checks.md` memory; future PRs will run `npm audit` + Dependabot delta as a pre-merge gate.

## Root cause

`@lhci/cli@0.15.1` pulls two incompatible copies of `tmp`:

```text
@lhci/cli@0.15.1
├── tmp@0.1.0                                  (direct, ^0.1.0 cap)
└── inquirer@6.5.2 → external-editor@3.1.0 → tmp@0.0.33 (^0.0.33 cap)
```

Both versions are < 0.2.4 (patched). Dependabot's `security_update_not_possible` error:

```text
conflicting-dependencies:
  - external-editor@3.1.0 requires tmp@^0.0.33
  - @lhci/cli@0.15.1 requires tmp@^0.1.0
lowest-non-vulnerable-version: 0.2.4
```

[Failed Dependabot run #25617601437](https://github.com/P47Phoenix/OpenDoorPH-website/actions/runs/25617601437)

## Fix

Add `tmp: "^0.2.4"` to `OpenDoorWebsiteApp/package.json` `overrides` — same pattern already used for 5 other transitive deps in this repo (`path-to-regexp`, `svgo`, `underscore`, `serialize-javascript`, `@tootallnate/once`).

```diff
   "overrides": {
     "path-to-regexp@<0.1.13": "0.1.13",
     "svgo@>=2.1.0 <2.8.1": "2.8.2",
     "underscore@<=1.13.7": "1.13.8",
     "serialize-javascript": "7.0.5",
-    "@tootallnate/once": "3.0.1"
+    "@tootallnate/once": "3.0.1",
+    "tmp": "^0.2.4"
   }
```

## Test plan

```text
$ npm ls tmp
opendoorwebsiteapp@0.2.0
└─┬ @lhci/cli@0.15.1
  ├─┬ inquirer@6.5.2
  │ └─┬ external-editor@3.1.0
  │   └── tmp@0.2.5 deduped
  └── tmp@0.2.5 overridden     ← BOTH paths now patched

$ npm test                           → 114/114 PASS  (existing CRA suite)
$ npm run test:seo                   → 62/62 PASS
$ npm run build:prod                 → exit 0
$ npx lhci --version                 → 0.15.1 (still functional after override)
$ node scripts/seo-monitor/seo-monitor.mjs canonical
  PASS canonical: opendoorph.info → 200 with <link rel=canonical>=https://opendoorph.org/
  PASS canonical: opendoorph.net  → 200 with <link rel=canonical>=https://opendoorph.org/
  PASS canonical: opendoorph.com  → 200 with <link rel=canonical>=https://opendoorph.org/
  PASS canonical: opendoorph.org  → https://opendoorph.org/
  SUMMARY canonical exit=0 pass=4 fail=0 warn=0 error=0
```

## Audit delta

`npm audit` total findings: 14 (9 high, 4 moderate, 1 low). All 9 highs trace to pre-existing CRA stack (`react-scripts` → `@svgr/webpack` → `css-select` → `nth-check` → `glob` → `@babel/...`) — none introduced by this override. The previously-flagged `tmp` LOW vulnerability is GONE.

Closes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)